### PR TITLE
improve exception handling when removing files

### DIFF
--- a/trashcli/fs.py
+++ b/trashcli/fs.py
@@ -1,16 +1,18 @@
-import os, shutil
+import os, shutil, errno
 
 class FileSystemListing:
     def entries_if_dir_exists(self, path):
         if os.path.exists(path):
-            for entry in os.listdir(path):
-                yield entry
+            try:
+                for entry in os.listdir(path):
+                    yield entry
+            except OSError:
+                pass
     def exists(self, path):
         return os.path.exists(path)
 
 class FileSystemReader(FileSystemListing):
     def is_sticky_dir(self, path):
-        import os
         return os.path.isdir(path) and has_sticky_bit(path)
     def is_symlink(self, path):
         return os.path.islink(path)
@@ -21,15 +23,21 @@ class FileRemover:
     def remove_file(self, path):
         try:
             return os.remove(path)
+        except OSError as e:
+            if e.errno == errno.EISDIR:
+                pass
+            else:
+                return
+        try:
+            return shutil.rmtree(path)
         except OSError:
-            shutil.rmtree(path)
+            pass
     def remove_file_if_exists(self,path):
         if os.path.exists(path): self.remove_file(path)
 
 def contents_of(path): # TODO remove
     return FileSystemReader().contents_of(path)
 def has_sticky_bit(path): # TODO move to FileSystemReader
-    import os
     import stat
     return (os.stat(path).st_mode & stat.S_ISVTX) == stat.S_ISVTX
 
@@ -40,8 +48,16 @@ def remove_file(path):
     if(os.path.exists(path)):
         try:
             os.remove(path)
-        except:
-            return shutil.rmtree(path)
+        except OSError as e:
+            if e.errno == errno.EISDIR:
+                pass
+            else:
+                return
+
+        try:
+            shutil.rmtree(path)
+        except OSError:
+            pass
 
 def move(path, dest) :
     return shutil.move(path, str(dest))


### PR DESCRIPTION
If the fs is readonly, or I otherwise don't have permission to delete something from a .Trash directory, trash-empty blows up with an uncaught exception.  This is a problem because trash-empty looks for .Trash directories on each mountpoint, some of which I don't have write access to.

Also, `os` is imported at the top level, no need to do local imports.
