### PR TITLE
Fix should_output_info_for_multiple_files

### DIFF
--- a/integration_tests/describe_trash_list.py
+++ b/integration_tests/describe_trash_list.py
@@ -73,9 +73,9 @@ class describe_trash_list(Setup):
 
         self.user.run_trash_list()
 
-        self.user.should_read_output( "2000-01-01 00:00:01 /file1\n"
-                                      "2000-01-01 00:00:02 /file2\n"
-                                      "2000-01-01 00:00:03 /file3\n")
+        self.user.should_read_output_any_order( "2000-01-01 00:00:01 /file1\n"
+                                                "2000-01-01 00:00:02 /file2\n"
+                                                "2000-01-01 00:00:03 /file3\n")
 
     @istest
     def should_output_unknown_dates_with_question_marks(self):
@@ -294,6 +294,8 @@ class TrashListUser:
         raise ValueError()
     def should_read_output(self, expected_value):
         self.stdout.assert_equal_to(expected_value)
+    def should_read_output_any_order(self, expected_value):
+        self.stdout.assert_equal_any_order(expected_value)
     def should_read_error(self, expected_value):
         self.stderr.assert_equal_to(expected_value)
     def output(self):

--- a/integration_tests/output_collector.py
+++ b/integration_tests/output_collector.py
@@ -9,6 +9,14 @@ class OutputCollector:
         self.stream.write(data)
     def assert_equal_to(self, expected):
         return self.should_be(expected)
+    def assert_equal_any_order(self, expected):
+        actual_sorted = sorted(self.stream.getvalue().splitlines(1))
+        actual = "".join(actual_sorted)
+
+        expected_sorted = sorted(expected.splitlines(1))
+        expected = "".join(expected_sorted)
+
+        assert_equals_with_unidiff(expected, actual)
     def should_be(self, expected):
         assert_equals_with_unidiff(expected, self.stream.getvalue())
     def should_match(self, regex):


### PR DESCRIPTION
Test should_output_info_for_multiple_files fails because the output is not in the same order as the input.  Make it pass irrespective of the order.
