### PR TITLE
Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.bak
 *.pyc
 *.swp
 *.tmp
@@ -6,12 +7,13 @@
 .local/
 
 # generated executables
-/trash-restore
-/trash-empty
-/trash-list
-/trash-put
-/trash-rm
+/trash-restore*
+/trash-empty*
+/trash-list*
+/trash-put*
+/trash-rm*
 /trash
+/trash34
 
 # other things
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.bak
 *.pyc
 *.swp
 *.tmp
@@ -7,13 +6,12 @@
 .local/
 
 # generated executables
-/trash-restore*
-/trash-empty*
-/trash-list*
-/trash-put*
-/trash-rm*
+/trash-restore
+/trash-empty
+/trash-list
+/trash-put
+/trash-rm
 /trash
-/trash34
 
 # other things
 /build/

--- a/check_release_installation.py
+++ b/check_release_installation.py
@@ -1,7 +1,7 @@
 TARGET_HOST = '192.168.56.101'
 
 import nose
-from nose.tools import assert_equals, assert_not_equals
+from nose.tools import assert_equal, assert_not_equal
 from ssh import Connection
 
 from trashcli.trash import version
@@ -41,7 +41,7 @@ class LinuxBox:
     def _assert_command_removed(self, executable):
         result = self.ssh.run('which %s' % executable)
         command_not_existent_exit_code_for_which = 1
-        assert_equals(result.exit_code, command_not_existent_exit_code_for_which,
+        assert_equal(result.exit_code, command_not_existent_exit_code_for_which,
                       'Which returned: %s\n' % result.exit_code +
                       'and reported: %s' % result.stdout
                       )
@@ -55,7 +55,7 @@ class LinuxBox:
     def check_all_programs_are_installed(self):
         for command in self.executables:
             result = self.ssh.run('%(command)s --version' % locals())
-            assert_not_equals(127, result.exit_code,
+            assert_not_equal(127, result.exit_code,
                     "Exit code was: %s, " % result.exit_code +
                     "Probably command not found, command: %s" % command)
 
@@ -82,13 +82,13 @@ class TestConnection:
         self.ssh = Connection(TARGET_HOST)
     def test_should_report_stdout(self):
         result = self.ssh.run('echo', 'foo')
-        assert_equals('foo\n', result.stdout)
+        assert_equal('foo\n', result.stdout)
     def test_should_report_stderr(self):
         result = self.ssh.run('echo bar 1>&2')
-        assert_equals('bar\n', result.stderr)
+        assert_equal('bar\n', result.stderr)
     def test_should_report_exit_code(self):
         result = self.ssh.run("exit 134")
-        assert_equals(134, result.exit_code)
+        assert_equal(134, result.exit_code)
 
 if __name__ == '__main__':
     main()

--- a/check_release_installation.py
+++ b/check_release_installation.py
@@ -13,13 +13,13 @@ def main():
 
 def check_installation(installation_method):
     tc = LinuxBox('root@' + TARGET_HOST, installation_method)
-    print "== Cleaning any prior software installation"
+    print("== Cleaning any prior software installation")
     tc.clean_any_prior_installation()
-    print "== Copying software"
+    print("== Copying software")
     tc.copy_tarball()
-    print "== Installing software"
+    print("== Installing software")
     tc.install_software()
-    print "== Checking all program were installed"
+    print("== Checking all program were installed")
     tc.check_all_programs_are_installed()
 
 

--- a/integration_tests/assert_equals_with_unidiff.py
+++ b/integration_tests/assert_equals_with_unidiff.py
@@ -11,8 +11,8 @@ def assert_equals_with_unidiff(expected, actual):
                                  lineterm='\n', n=10)
 
         return ''.join(diff)
-    from nose.tools import assert_equals
-    assert_equals(expected, actual,
+    from nose.tools import assert_equal
+    assert_equal(expected, actual,
                   "\n"
                   "Expected:%s\n" % repr(expected) +
                   "  Actual:%s\n" % repr(actual) +

--- a/integration_tests/describe_trash_list.py
+++ b/integration_tests/describe_trash_list.py
@@ -2,12 +2,12 @@
 
 import os
 from trashcli.trash import ListCmd
-from files import (write_file, require_empty_dir, make_sticky_dir,
+from .files import (write_file, require_empty_dir, make_sticky_dir,
                    make_unsticky_dir, make_unreadable_file, make_empty_file,
                    make_parent_for)
 from nose.tools import istest
 from .output_collector import OutputCollector
-from trashinfo import (
+from .trashinfo import (
         a_trashinfo,
         a_trashinfo_without_date,
         a_trashinfo_without_path,

--- a/integration_tests/files.py
+++ b/integration_tests/files.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 from trashcli.fs  import has_sticky_bit
 import os, shutil
 
@@ -14,14 +14,14 @@ make_empty_file = having_file
 def write_file(filename, contents=''):
     parent = os.path.dirname(filename)
     if not os.path.isdir(parent): os.makedirs(parent)
-    file(filename, 'w').write(contents)
-    assert_equals(file(filename).read(), contents)
+    open(filename, 'wt').write(contents)
+    assert_equal(open(filename).read(), contents)
 
 def require_empty_dir(path):
     if os.path.exists(path): shutil.rmtree(path)
     make_dirs(path)
     assert os.path.isdir(path)
-    assert_equals([], list(os.listdir(path)))
+    assert_equal([], list(os.listdir(path)))
 
 def having_empty_dir(path):
     require_empty_dir(path)
@@ -73,5 +73,5 @@ def make_unreadable_file(path):
     os.chmod(path, 0)
     from nose.tools import assert_raises
     with assert_raises(IOError):
-        file(path).read()
+        open(path).read()
 

--- a/integration_tests/output_collector.py
+++ b/integration_tests/output_collector.py
@@ -2,7 +2,11 @@ from .assert_equals_with_unidiff import assert_equals_with_unidiff
 
 class OutputCollector:
     def __init__(self):
-        from StringIO import StringIO
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+        try:
+            from StringIO import StringIO
+        except ImportError:
+            from io import StringIO
         self.stream = StringIO()
         self.getvalue = self.stream.getvalue
     def write(self,data):

--- a/integration_tests/output_collector.py
+++ b/integration_tests/output_collector.py
@@ -1,4 +1,4 @@
-from assert_equals_with_unidiff import assert_equals_with_unidiff
+from .assert_equals_with_unidiff import assert_equals_with_unidiff
 
 class OutputCollector:
     def __init__(self):

--- a/integration_tests/test_file_descriptions.py
+++ b/integration_tests/test_file_descriptions.py
@@ -2,7 +2,7 @@
 
 from trashcli.put import describe
 from .files import require_empty_dir, having_file
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 import os
 
 class TestDescritions:
@@ -11,41 +11,41 @@ class TestDescritions:
 
     def test_on_directories(self):
 
-        assert_equals("directory", describe('.'))
-        assert_equals("directory", describe(".."))
-        assert_equals("directory", describe("sandbox"))
+        assert_equal("directory", describe('.'))
+        assert_equal("directory", describe(".."))
+        assert_equal("directory", describe("sandbox"))
 
     def test_on_dot_directories(self):
 
-        assert_equals("`.' directory",  describe("sandbox/."))
-        assert_equals("`.' directory",  describe("./."))
+        assert_equal("`.' directory",  describe("sandbox/."))
+        assert_equal("`.' directory",  describe("./."))
 
     def test_on_dot_dot_directories(self):
 
-        assert_equals("`..' directory", describe("./.."))
-        assert_equals("`..' directory", describe("sandbox/.."))
+        assert_equal("`..' directory", describe("./.."))
+        assert_equal("`..' directory", describe("sandbox/.."))
 
     def test_name_for_regular_files_non_empty_files(self):
 
         write_file("sandbox/non-empty", "contents")
-        assert_equals("regular file", describe("sandbox/non-empty"))
+        assert_equal("regular file", describe("sandbox/non-empty"))
 
     def test_name_for_empty_file(self):
 
         having_file('sandbox/empty')
-        assert_equals("regular empty file", describe("sandbox/empty"))
+        assert_equal("regular empty file", describe("sandbox/empty"))
 
     def test_name_for_symbolic_links(self):
 
         os.symlink('nowhere', "sandbox/symlink")
 
-        assert_equals("symbolic link", describe("sandbox/symlink"))
+        assert_equal("symbolic link", describe("sandbox/symlink"))
 
     def test_name_for_non_existent_entries(self):
 
         assert not os.path.exists('non-existent')
 
-        assert_equals("non existent", describe('non-existent'))
+        assert_equal("non existent", describe('non-existent'))
 
 def write_file(path, contents):
     f = open(path, 'w')

--- a/integration_tests/test_listing_all_trashinfo_in_a_trashdir.py
+++ b/integration_tests/test_listing_all_trashinfo_in_a_trashdir.py
@@ -1,7 +1,7 @@
 from trashcli.trash import TrashDirectory
 
-from files import require_empty_dir
-from files import write_file
+from .files import require_empty_dir
+from .files import write_file
 from nose.tools import assert_equals, assert_items_equal
 from mock import Mock
 

--- a/integration_tests/test_listing_all_trashinfo_in_a_trashdir.py
+++ b/integration_tests/test_listing_all_trashinfo_in_a_trashdir.py
@@ -2,8 +2,19 @@ from trashcli.trash import TrashDirectory
 
 from .files import require_empty_dir
 from .files import write_file
-from nose.tools import assert_equals, assert_items_equal
-from mock import Mock
+from nose.tools import assert_equal
+
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from nose.tools import assert_items_equal
+except ImportError:
+    from nose.tools import assert_count_equal as assert_items_equal
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 class TestWhenListingTrashinfo:
     def setUp(self):
@@ -18,7 +29,7 @@ class TestWhenListingTrashinfo:
 
         result = self.list_trashinfos()
 
-        assert_equals(['sandbox/info/foo.trashinfo'], result)
+        assert_equal(['sandbox/info/foo.trashinfo'], result)
 
     def test_should_list_multiple_trashinfo(self):
         write_file('sandbox/info/foo.trashinfo')
@@ -36,7 +47,7 @@ class TestWhenListingTrashinfo:
 
         result = self.list_trashinfos()
 
-        assert_equals([], result)
+        assert_equal([], result)
 
     def test_non_trashinfo_should_reported_as_a_warn(self):
         write_file('sandbox/info/not-a-trashinfo')

--- a/integration_tests/test_persist.py
+++ b/integration_tests/test_persist.py
@@ -2,7 +2,7 @@
 
 import os
 
-from nose.tools import assert_equals, assert_true
+from nose.tools import assert_equal, assert_true
 
 from integration_tests.files import require_empty_dir
 from trashcli.put import TrashDirectoryForPut
@@ -26,9 +26,9 @@ class TestTrashDirectory_persit_trash_info:
     def test_persist_trash_info_first_time(self):
 
         trash_info_file = self.persist_trash_info('dummy-path', 'content')
-        assert_equals(join(self.trashdirectory_base_dir,'info', 'dummy-path.trashinfo'), trash_info_file)
+        assert_equal(join(self.trashdirectory_base_dir,'info', 'dummy-path.trashinfo'), trash_info_file)
 
-        assert_equals('content', read(trash_info_file))
+        assert_equal('content', read(trash_info_file))
 
     def test_persist_trash_info_first_100_times(self):
         self.test_persist_trash_info_first_time()
@@ -37,9 +37,9 @@ class TestTrashDirectory_persit_trash_info:
             content='trashinfo content'
             trash_info_file = self.persist_trash_info('dummy-path', content)
 
-            assert_equals("dummy-path_%s.trashinfo" % i,
+            assert_equal("dummy-path_%s.trashinfo" % i,
                     os.path.basename(trash_info_file))
-            assert_equals('trashinfo content', read(trash_info_file))
+            assert_equal('trashinfo content', read(trash_info_file))
 
     def test_persist_trash_info_other_times(self):
         self.test_persist_trash_info_first_100_times()
@@ -48,10 +48,10 @@ class TestTrashDirectory_persit_trash_info:
             trash_info_file = self.persist_trash_info('dummy-path','content')
             trash_info_id = os.path.basename(trash_info_file)
             assert_true(trash_info_id.startswith("dummy-path_"))
-            assert_equals('content', read(trash_info_file))
+            assert_equal('content', read(trash_info_file))
     test_persist_trash_info_first_100_times.stress_test = True
     test_persist_trash_info_other_times.stress_test = True
 
 def read(path):
-    return file(path).read()
+    return open(path).read()
 

--- a/integration_tests/test_restore_trash.py
+++ b/integration_tests/test_restore_trash.py
@@ -4,7 +4,7 @@ from trashcli.trash import RestoreCmd
 
 from .files import require_empty_dir
 from .output_collector import OutputCollector
-from trashinfo import a_trashinfo
+from .trashinfo import a_trashinfo
 
 @istest
 class describe_restore_trash:

--- a/integration_tests/test_restore_trash.py
+++ b/integration_tests/test_restore_trash.py
@@ -56,7 +56,7 @@ class describe_restore_trash:
                 with_user_typing = '0')
 
         self.file_should_have_been_restored('foo')
-    
+
     @istest
     def it_should_exit_gracefully_when_user_selects_nothing(self):
 
@@ -71,7 +71,7 @@ class describe_restore_trash:
     def it_should_refuse_overwriting_existing_file(self):
 
         self.having_a_file_trashed_from_current_dir('foo')
-        file('foo', 'a+').close()
+        open('foo', 'a+').close()
         os.chmod('foo', 000)
         self.when_running_restore_trash(from_dir=current_dir(),
                                         with_user_typing = '0')

--- a/integration_tests/test_trash_empty.py
+++ b/integration_tests/test_trash_empty.py
@@ -1,15 +1,30 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
-from nose.tools import (assert_equals,
-                        assert_items_equal,
-                        istest)
+from nose.tools import assert_equal, istest
+
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from nose.tools import assert_items_equal
+except ImportError:
+    from nose.tools import assert_count_equal as assert_items_equal
+
 from trashcli.trash import EmptyCmd
 
-from StringIO import StringIO
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 import os
 from .files import write_file, require_empty_dir, make_dirs, set_sticky_bit
 from .files import having_file
-from mock import MagicMock
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 @istest
 class WhenCalledWithoutArguments:
@@ -214,7 +229,7 @@ class TestTrashEmpty_on_help:
                        environ = {},
                        list_volumes = no_volumes,)
         cmd.run('trash-empty', '--help')
-        assert_equals(out.getvalue(), dedent("""\
+        assert_equal(out.getvalue(), dedent("""\
             Usage: trash-empty [days]
 
             Purge trashed files.
@@ -235,7 +250,7 @@ class TestTrashEmpty_on_version():
                        version = '1.2.3',
                        list_volumes = no_volumes,)
         cmd.run('trash-empty', '--version')
-        assert_equals(out.getvalue(), dedent("""\
+        assert_equal(out.getvalue(), dedent("""\
             trash-empty 1.2.3
             """))
 
@@ -253,13 +268,13 @@ class describe_trash_empty_command_line__on_invalid_options():
         self.exit_code = self.cmd.run('trash-empty', '-2')
 
         exit_code_for_command_line_usage = 64
-        assert_equals(exit_code_for_command_line_usage, self.exit_code)
+        assert_equal(exit_code_for_command_line_usage, self.exit_code)
 
     def it_should_complain_to_the_standard_error(self):
 
         self.exit_code = self.cmd.run('trash-empty', '-2')
 
-        assert_equals(self.err.getvalue(), dedent("""\
+        assert_equal(self.err.getvalue(), dedent("""\
                 trash-empty: invalid option -- '2'
                 """))
 
@@ -267,7 +282,7 @@ class describe_trash_empty_command_line__on_invalid_options():
 
         self.cmd.run('trash-empty', '-3')
 
-        assert_equals(self.err.getvalue(), dedent("""\
+        assert_equal(self.err.getvalue(), dedent("""\
                 trash-empty: invalid option -- '3'
                 """))
 

--- a/integration_tests/test_trash_empty.py
+++ b/integration_tests/test_trash_empty.py
@@ -7,8 +7,8 @@ from trashcli.trash import EmptyCmd
 
 from StringIO import StringIO
 import os
-from files import write_file, require_empty_dir, make_dirs, set_sticky_bit
-from files import having_file
+from .files import write_file, require_empty_dir, make_dirs, set_sticky_bit
+from .files import having_file
 from mock import MagicMock
 
 @istest

--- a/integration_tests/test_trash_put.py
+++ b/integration_tests/test_trash_put.py
@@ -2,7 +2,7 @@
 from trashcli.put import TrashPutCmd
 
 import os
-from nose.tools import istest, assert_equals, assert_not_equals
+from nose.tools import istest, assert_equal, assert_not_equal
 from nose.tools import assert_in
 
 from .files import having_file, require_empty_dir, having_empty_dir
@@ -56,7 +56,7 @@ class when_deleting_an_existing_file(TrashPutTest):
 
     @istest
     def a_trashinfo_file_should_have_been_created(self):
-        file('sandbox/XDG_DATA_HOME/Trash/info/foo.trashinfo').read()
+        open('sandbox/XDG_DATA_HOME/Trash/info/foo.trashinfo').read()
 
 @istest
 class when_deleting_an_existing_file_in_verbose_mode(TrashPutTest):
@@ -71,7 +71,7 @@ class when_deleting_an_existing_file_in_verbose_mode(TrashPutTest):
 
     @istest
     def should_be_succesfull(self):
-        assert_equals(0, self.exit_code)
+        assert_equal(0, self.exit_code)
 
 @istest
 class when_deleting_a_non_existing_file(TrashPutTest):
@@ -80,7 +80,7 @@ class when_deleting_a_non_existing_file(TrashPutTest):
 
     @istest
     def should_be_succesfull(self):
-        assert_not_equals(0, self.exit_code)
+        assert_not_equal(0, self.exit_code)
 
 @istest
 class when_fed_with_dot_arguments(TrashPutTest):

--- a/integration_tests/test_trash_rm.py
+++ b/integration_tests/test_trash_rm.py
@@ -2,9 +2,9 @@ from StringIO import StringIO
 from mock import Mock, ANY
 from nose.tools import assert_false, assert_raises
 
-from files import require_empty_dir, write_file
+from .files import require_empty_dir, write_file
 from trashcli.rm import Main, ListTrashinfos
-from trashinfo import a_trashinfo_with_path
+from .trashinfo import a_trashinfo_with_path
 
 
 class TestTrashRm:

--- a/integration_tests/test_trash_rm.py
+++ b/integration_tests/test_trash_rm.py
@@ -1,5 +1,13 @@
-from StringIO import StringIO
-from mock import Mock, ANY
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+try:
+    from unittest.mock import Mock, ANY
+except ImportError:
+    from mock import Mock, ANY
+
 from nose.tools import assert_false, assert_raises
 
 from .files import require_empty_dir, write_file

--- a/integration_tests/test_trash_rm_script.py
+++ b/integration_tests/test_trash_rm_script.py
@@ -1,7 +1,6 @@
-from nose.tools import istest, assert_equals, assert_in
+from nose.tools import istest, assert_in
 import subprocess
 from subprocess import STDOUT, PIPE, check_output, call, Popen
-from .assert_equals_with_unidiff import assert_equals_with_unidiff as assert_equals
 from textwrap import dedent
 
 from pprint import pprint
@@ -20,5 +19,11 @@ class WhenNoArgs:
         self.returncode = process.returncode
 
     def test_should_print_usage_on_standard_error(self):
-        assert_in("Usage:", self.stderr.splitlines())
+        content = self.stderr
+        if isinstance(content, str):
+#           Python 2:
+            assert_in("Usage:", content.splitlines())
+        else:
+#           Python 3:
+            assert_in("Usage:", content.decode().splitlines())
 

--- a/integration_tests/test_trash_rm_script.py
+++ b/integration_tests/test_trash_rm_script.py
@@ -1,7 +1,7 @@
 from nose.tools import istest, assert_equals, assert_in
 import subprocess
 from subprocess import STDOUT, PIPE, check_output, call, Popen
-from assert_equals_with_unidiff import assert_equals_with_unidiff as assert_equals
+from .assert_equals_with_unidiff import assert_equals_with_unidiff as assert_equals
 from textwrap import dedent
 
 from pprint import pprint

--- a/ssh.py
+++ b/ssh.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 import subprocess
 
 class Connection:
@@ -25,7 +25,7 @@ class Connection:
             self.stderr = stderr
             self.exit_code = exit_code
         def assert_no_err(self):
-            assert_equals('', self.stderr)
+            assert_equal('', self.stderr)
         def assert_succesful(self):
             assert self.exit_code == 0
 

--- a/trashcli/cmds.py
+++ b/trashcli/cmds.py
@@ -4,13 +4,24 @@ import sys,os
 
 def restore():
     from trashcli.trash import RestoreCmd
-    RestoreCmd(
-        stdout  = sys.stdout,
-        stderr  = sys.stderr,
-        environ = os.environ,
-        exit    = sys.exit,
-        input   = raw_input
-    ).run(sys.argv)
+# Try Python 2 raw_input function; if NameError occurs, use Python 3 input function
+    try:
+        RestoreCmd(
+            stdout  = sys.stdout,
+            stderr  = sys.stderr,
+            environ = os.environ,
+            exit    = sys.exit,
+            input   = raw_input
+        ).run(sys.argv)
+    except NameError:
+        RestoreCmd(
+            stdout  = sys.stdout,
+            stderr  = sys.stderr,
+            environ = os.environ,
+            exit    = sys.exit,
+            input   = input
+        ).run(sys.argv)
+
 
 def empty():
     from trashcli.trash import EmptyCmd

--- a/trashcli/fs.py
+++ b/trashcli/fs.py
@@ -1,4 +1,4 @@
-import os, shutil
+import os, shutil, sys
 
 class FileSystemListing:
     def entries_if_dir_exists(self, path):
@@ -59,7 +59,7 @@ def mkdirs(path):
 def atomic_write(filename, content):
     file_handle = os.open(filename, os.O_RDWR | os.O_CREAT | os.O_EXCL,
             0o600)
-    if isinstance(content, str):
+    if sys.version_info > (3,):
 #       Encode Python 3 unicode:
         os.write(file_handle, content.encode())
     else:

--- a/trashcli/fs.py
+++ b/trashcli/fs.py
@@ -58,7 +58,7 @@ def mkdirs(path):
 
 def atomic_write(filename, content):
     file_handle = os.open(filename, os.O_RDWR | os.O_CREAT | os.O_EXCL,
-            0600)
+            0o600)
     os.write(file_handle, content)
     os.close(file_handle)
 

--- a/trashcli/fs.py
+++ b/trashcli/fs.py
@@ -15,7 +15,7 @@ class FileSystemReader(FileSystemListing):
     def is_symlink(self, path):
         return os.path.islink(path)
     def contents_of(self, path):
-        return file(path).read()
+        return open(path).read()
 
 class FileRemover:
     def remove_file(self, path):
@@ -59,7 +59,12 @@ def mkdirs(path):
 def atomic_write(filename, content):
     file_handle = os.open(filename, os.O_RDWR | os.O_CREAT | os.O_EXCL,
             0o600)
-    os.write(file_handle, content)
+    if isinstance(content, str):
+#       Encode Python 3 unicode:
+        os.write(file_handle, content.encode())
+    else:
+#       Python 2:
+        os.write(file_handle, content)
     os.close(file_handle)
 
 def ensure_dir(path, mode):

--- a/trashcli/list_mount_points.py
+++ b/trashcli/list_mount_points.py
@@ -2,7 +2,7 @@
 
 def mount_points():
     try:
-	return list(mount_points_from_getmnt())
+        return list(mount_points_from_getmnt())
     except AttributeError:
         return mount_points_from_df()
 
@@ -17,14 +17,14 @@ def mount_points_from_df():
 
 def _mount_points_from_df_output(df_output):
     def skip_header():
-	df_output.readline()
+        df_output.readline()
     def chomp(string):
-	return string.rstrip('\n')
+        return string.rstrip('\n')
 
     skip_header()
     for line in df_output:
-	line = chomp(line)
-	yield line.split(None, 5)[-1]
+        line = chomp(line)
+        yield line.split(None, 5)[-1]
 
 def _mounted_filesystems_from_getmnt() :
     from ctypes import Structure, c_char_p, c_int, c_void_p, cdll, POINTER

--- a/trashcli/put.py
+++ b/trashcli/put.py
@@ -252,7 +252,7 @@ class GlobalTrashCan:
                             trashed_file['where_file_was_stored'])
                         file_has_been_trashed = True
 
-                    except (IOError, OSError), error:
+                    except (IOError, OSError) as error:
                         self.reporter.unable_to_trash_file_in_because(
                                 file, trash_dir.path, str(error))
 
@@ -390,7 +390,7 @@ class TrashDirectoryForPut:
         return content
 
     def ensure_files_dir_exists(self):
-        self.ensure_dir(self.files_dir, 0700)
+        self.ensure_dir(self.files_dir, 0o700)
 
     def persist_trash_info(self, info_dir, basename, content) :
         """
@@ -398,7 +398,7 @@ class TrashDirectoryForPut:
         returns the created TrashInfoFile.
         """
 
-        self.ensure_dir(info_dir, 0700)
+        self.ensure_dir(info_dir, 0o700)
 
         # write trash info
         index = 0

--- a/trashcli/trash.py
+++ b/trashcli/trash.py
@@ -623,7 +623,11 @@ class ParseTrashInfo:
         self.found_path = on_path
     def __call__(self, contents):
         from datetime import datetime
-        import urllib
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+        try:
+            from urllib.parse import unquote
+        except ImportError:
+            from urllib import unquote
         for line in contents.split('\n'):
             if line.startswith('DeletionDate='):
                 try:
@@ -634,7 +638,7 @@ class ParseTrashInfo:
                     self.found_deletion_date(date)
 
             if line.startswith('Path='):
-                path=urllib.unquote(line[len('Path='):])
+                path=unquote(line[len('Path='):])
                 self.found_path(path)
 
 class Basket:
@@ -648,9 +652,19 @@ def parse_deletion_date(contents):
     return result.collected
 
 def parse_path(contents):
-    import urllib
-    for line in contents.split('\n'):
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+    try:
+        from urllib.parse import unquote
+    except ImportError:
+        from urllib import unquote
+    if isinstance(contents, str):
+#       Python 2:
+        output = contents
+    else:
+#       Python 3:
+        output = bytes.decode(contents)
+    for line in output.split('\n'):
         if line.startswith('Path='):
-            return urllib.unquote(line[len('Path='):])
+            return unquote(line[len('Path='):])
     raise ParseError('Unable to parse Path')
 

--- a/trashcli/trash.py
+++ b/trashcli/trash.py
@@ -307,7 +307,7 @@ class Parser:
             options, arguments = getopt(argv[1:],
                                         self.short_options,
                                         self.long_options)
-        except GetoptError, e:
+        except GetoptError as e:
             invalid_option = e.opt
             self._on_invalid_option(program_name, invalid_option)
         else:

--- a/unit_tests/test_fake_fstab.py
+++ b/unit_tests/test_fake_fstab.py
@@ -1,8 +1,12 @@
 from trashcli.fstab import FakeFstab
 
-from nose.tools import assert_equals
-from nose.tools import istest
-from nose.tools import assert_items_equal
+from nose.tools import assert_equal, istest
+
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from nose.tools import assert_items_equal
+except ImportError:
+    from nose.tools import assert_count_equal as assert_items_equal
 
 class TestFakeFstab:
     def setUp(self):
@@ -28,7 +32,7 @@ class TestFakeFstab:
     def test_something(self):
         fstab = FakeFstab()
         fstab.add_mount('/fake')
-        assert_equals('/fake', fstab.volume_of('/fake/foo'))
+        assert_equal('/fake', fstab.volume_of('/fake/foo'))
 
     def assert_mount_points_are(self, *expected_mounts):
         expected_mounts = list(expected_mounts)

--- a/unit_tests/test_global_trashcan.py
+++ b/unit_tests/test_global_trashcan.py
@@ -1,4 +1,9 @@
-from mock import Mock
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 from nose.tools import istest
 
 from trashcli.put import GlobalTrashCan

--- a/unit_tests/test_home_fallback.py
+++ b/unit_tests/test_home_fallback.py
@@ -1,8 +1,12 @@
-from mock import Mock, call, ANY
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock, call, ANY
+except ImportError:
+    from mock import Mock, call, ANY
 
 from trashcli.fstab import FakeFstab
 from trashcli.put import GlobalTrashCan
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 
 class TestHomeFallback:
     def setUp(self):
@@ -25,7 +29,7 @@ class TestHomeFallback:
 
         self.trashcan.trash('sandbox/foo')
 
-        assert_equals([
+        assert_equal([
             call.isdir('.Trash'),
             call.islink('.Trash'),
             call.ensure_dir('.Trash/123/info', 448),
@@ -54,9 +58,9 @@ class TestTrashDirectories:
                 environ      = self.environ)
 
         result = trash_dirs.all_trash_directories()
-        paths = map(lambda td: td.path, result)
+        paths = [td.path for td in result]
 
-        assert_equals( ['~/.local/share/Trash',
+        assert_equal( ['~/.local/share/Trash',
                         '/.Trash/123',
                         '/.Trash-123',
                         '/mnt/.Trash/123',

--- a/unit_tests/test_joining_paths.py
+++ b/unit_tests/test_joining_paths.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 
 def test_how_path_joining_works():
     from os.path import join
-    assert_equals('/another-absolute', join('/absolute', '/another-absolute'))
-    assert_equals('/absolute/relative', join('/absolute', 'relative'))
-    assert_equals('/absolute', join('relative', '/absolute'))
-    assert_equals('relative/relative', join('relative', 'relative'))
-    assert_equals('/absolute', join('', '/absolute'))
-    assert_equals('/absolute', join(None, '/absolute'))
+    assert_equal('/another-absolute', join('/absolute', '/another-absolute'))
+    assert_equal('/absolute/relative', join('/absolute', 'relative'))
+    assert_equal('/absolute', join('relative', '/absolute'))
+    assert_equal('relative/relative', join('relative', 'relative'))
+    assert_equal('/absolute', join('', '/absolute'))
+    assert_equal('/absolute', join(None, '/absolute'))

--- a/unit_tests/test_list_all_trashinfo_contents.py
+++ b/unit_tests/test_list_all_trashinfo_contents.py
@@ -1,5 +1,14 @@
-from mock import Mock, call
-from nose.tools import assert_equals, assert_items_equal
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock, call
+except ImportError:
+    from mock import Mock, call
+
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from nose.tools import assert_items_equal
+except ImportError:
+    from nose.tools import assert_count_equal as assert_items_equal
 
 class TestListing:
     def setUp(self):

--- a/unit_tests/test_list_mount_points.py
+++ b/unit_tests/test_list_mount_points.py
@@ -7,35 +7,35 @@ from trashcli.list_mount_points import _mount_points_from_df_output
 class MountPointFromDirTest(unittest.TestCase):
 
     def test_should_skip_the_first_line(self):
-	mount_points = _mount_points_from_df_output(StringIO.StringIO(
-	'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
-	))
+        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
+        ))
 
-	self.assertEquals([], list(mount_points))
+        self.assertEquals([], list(mount_points))
 
     def test_should_return_the_first_mount_point(self):
-	mount_points = _mount_points_from_df_output(StringIO.StringIO(
-	'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
-	'/dev/disk0s2         243862672 121934848 121671824      51% /\n'
-	))
+        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
+        '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
+        ))
 
-	self.assertEquals(['/'], list(mount_points))
+        self.assertEquals(['/'], list(mount_points))
 
     def test_should_return_multiple_mount_point(self):
-	mount_points = _mount_points_from_df_output(StringIO.StringIO(
-	'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
-	'/dev/disk0s2         243862672 121934848 121671824      51% /\n'
-	'/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/DISK\n'
-	))
+        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
+        '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
+        '/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/DISK\n'
+        ))
 
-	self.assertEquals(['/', '/Volumes/DISK'], list(mount_points))
+        self.assertEquals(['/', '/Volumes/DISK'], list(mount_points))
 
     def test_should_return_mount_point_with_white_spaces(self):
-	mount_points = _mount_points_from_df_output(StringIO.StringIO(
-	'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
-	'/dev/disk0s2         243862672 121934848 121671824      51% /\n'
-	'/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/with white spaces\n'
-	))
+        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
+        '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
+        '/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/with white spaces\n'
+        ))
 
-	self.assertEquals(['/', '/Volumes/with white spaces'], list(mount_points))
+        self.assertEquals(['/', '/Volumes/with white spaces'], list(mount_points))
 

--- a/unit_tests/test_list_mount_points.py
+++ b/unit_tests/test_list_mount_points.py
@@ -1,20 +1,26 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
 import unittest
-import StringIO
+
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 from trashcli.list_mount_points import _mount_points_from_df_output
 
 class MountPointFromDirTest(unittest.TestCase):
 
     def test_should_skip_the_first_line(self):
-        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        mount_points = _mount_points_from_df_output(StringIO(
         'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
         ))
 
         self.assertEquals([], list(mount_points))
 
     def test_should_return_the_first_mount_point(self):
-        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        mount_points = _mount_points_from_df_output(StringIO(
         'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
         '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
         ))
@@ -22,7 +28,7 @@ class MountPointFromDirTest(unittest.TestCase):
         self.assertEquals(['/'], list(mount_points))
 
     def test_should_return_multiple_mount_point(self):
-        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        mount_points = _mount_points_from_df_output(StringIO(
         'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
         '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
         '/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/DISK\n'
@@ -31,7 +37,7 @@ class MountPointFromDirTest(unittest.TestCase):
         self.assertEquals(['/', '/Volumes/DISK'], list(mount_points))
 
     def test_should_return_mount_point_with_white_spaces(self):
-        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        mount_points = _mount_points_from_df_output(StringIO(
         'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
         '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
         '/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/with white spaces\n'

--- a/unit_tests/test_make_script.py
+++ b/unit_tests/test_make_script.py
@@ -1,7 +1,18 @@
 from textwrap import dedent
-from nose.tools import assert_equals
-import mock
-from mock import Mock
+from nose.tools import assert_equal
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 from setup import Scripts
 
 class TestMakeScript:
@@ -34,7 +45,7 @@ class TestMakeScript:
             from trashcli.cmds import put as main
             sys.exit(main())
             """)
-        assert_equals(expected, contents,
+        assert_equal(expected, contents,
                       "Expected:\n---\n%s---\n"
                       "Actual  :\n---\n%s---\n"
                       % (expected, contents))
@@ -46,8 +57,8 @@ class TestListOfCreatedScripts:
                 write_file           = Mock())
 
     def test_is_empty_on_start_up(self):
-        assert_equals(self.bindir.created_scripts, [])
+        assert_equal(self.bindir.created_scripts, [])
 
     def test_collect_added_script(self):
         self.bindir.add_script('foo-command', 'foo-module', 'main')
-        assert_equals(self.bindir.created_scripts, ['foo-command'])
+        assert_equal(self.bindir.created_scripts, ['foo-command'])

--- a/unit_tests/test_method1_security_check.py
+++ b/unit_tests/test_method1_security_check.py
@@ -1,4 +1,8 @@
-from mock import Mock
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from integration_tests.files import require_empty_dir
 from trashcli.put import TopTrashDirWriteRules

--- a/unit_tests/test_parser.py
+++ b/unit_tests/test_parser.py
@@ -1,5 +1,11 @@
 from trashcli.trash import Parser
-from mock import MagicMock
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
 from nose.tools import istest
 
 @istest

--- a/unit_tests/test_parsing_trashinfo_contents.py
+++ b/unit_tests/test_parsing_trashinfo_contents.py
@@ -1,10 +1,15 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
-from nose.tools import assert_equals, assert_raises
+from nose.tools import assert_equal, assert_raises
 from nose.tools import istest
 
 from datetime import datetime
-from mock import MagicMock
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from trashcli.trash import ParseTrashInfo
 
@@ -18,7 +23,7 @@ class describe_ParseTrashInfo2:
         parse('[Trash Info]\n'
               'Path=foo\n'
               'DeletionDate=1970-01-01T00:00:00\n')
-        
+
         out.assert_called_with(datetime(1970,1,1,0,0,0))
 
     @istest
@@ -37,9 +42,9 @@ from trashcli.trash import parse_path
 
 def test_how_to_parse_date_from_trashinfo():
     from datetime import datetime
-    assert_equals(datetime(2000,12,31,23,59,58), parse_deletion_date('DeletionDate=2000-12-31T23:59:58'))
-    assert_equals(datetime(2000,12,31,23,59,58), parse_deletion_date('DeletionDate=2000-12-31T23:59:58\n'))
-    assert_equals(datetime(2000,12,31,23,59,58), parse_deletion_date('[Trash Info]\nDeletionDate=2000-12-31T23:59:58'))
+    assert_equal(datetime(2000,12,31,23,59,58), parse_deletion_date('DeletionDate=2000-12-31T23:59:58'))
+    assert_equal(datetime(2000,12,31,23,59,58), parse_deletion_date('DeletionDate=2000-12-31T23:59:58\n'))
+    assert_equal(datetime(2000,12,31,23,59,58), parse_deletion_date('[Trash Info]\nDeletionDate=2000-12-31T23:59:58'))
 
 from trashcli.trash import maybe_parse_deletion_date
 
@@ -48,24 +53,24 @@ UNKNOWN_DATE='????-??-?? ??:??:??'
 class describe_maybe_parse_deletion_date:
     @istest
     def on_trashinfo_without_date_parse_to_unknown_date(self):
-        assert_equals(UNKNOWN_DATE, 
+        assert_equal(UNKNOWN_DATE,
                       maybe_parse_deletion_date(a_trashinfo_without_deletion_date()))
     @istest
     def on_trashinfo_with_date_parse_to_date(self):
         from datetime import datetime
         example_date_as_string='2001-01-01T00:00:00'
         same_date_as_datetime=datetime(2001,1,1)
-        assert_equals(same_date_as_datetime, 
+        assert_equal(same_date_as_datetime,
                       maybe_parse_deletion_date(make_trashinfo(example_date_as_string)))
     @istest
     def on_trashinfo_with_invalid_date_parse_to_unknown_date(self):
         invalid_date='A long time ago'
-        assert_equals(UNKNOWN_DATE,
+        assert_equal(UNKNOWN_DATE,
                       maybe_parse_deletion_date(make_trashinfo(invalid_date)))
 
 def test_how_to_parse_original_path():
-    assert_equals('foo.txt',             parse_path('Path=foo.txt'))
-    assert_equals('/path/to/be/escaped', parse_path('Path=%2Fpath%2Fto%2Fbe%2Fescaped'))
+    assert_equal('foo.txt',             parse_path('Path=foo.txt'))
+    assert_equal('/path/to/be/escaped', parse_path('Path=%2Fpath%2Fto%2Fbe%2Fescaped'))
 
 
 from trashcli.trash import LazyTrashInfoParser, ParseError
@@ -74,7 +79,7 @@ class TestParsing:
     def test_1(self):
         parser = LazyTrashInfoParser(lambda:("[Trash Info]\n"
                                              "Path=/foo.txt\n"), volume_path = '/')
-        assert_equals('/foo.txt', parser.original_location())
+        assert_equal('/foo.txt', parser.original_location())
 
 class TestLazyTrashInfoParser_with_empty_trashinfo:
     def setUp(self):
@@ -94,6 +99,4 @@ def make_trashinfo(date):
             "DeletionDate=%s" % date)
 def an_empty_trashinfo():
     return ''
-
-
 

--- a/unit_tests/test_restore_cmd.py
+++ b/unit_tests/test_restore_cmd.py
@@ -1,6 +1,11 @@
 from trashcli.trash import RestoreCmd
-from nose.tools import assert_equals
-from StringIO import StringIO
+from nose.tools import assert_equal
+
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 class TestTrashRestoreCmd:
     def test_should_print_version(self):
@@ -14,5 +19,5 @@ class TestTrashRestoreCmd:
 
         cmd.run(['trash-restore', '--version'])
 
-        assert_equals('trash-restore 1.2.3\n', stdout.getvalue())
+        assert_equal('trash-restore 1.2.3\n', stdout.getvalue())
 

--- a/unit_tests/test_shrink_user.py
+++ b/unit_tests/test_shrink_user.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 from trashcli.put import shrinkuser
 
 class TestTrashDirectoryName:
@@ -32,5 +32,5 @@ class TestTrashDirectoryName:
 
     def assert_name_is(self, expected_name):
         shrinked = shrinkuser(self.trash_dir, self.environ)
-        assert_equals(expected_name, shrinked)
+        assert_equal(expected_name, shrinked)
 

--- a/unit_tests/test_storing_paths.py
+++ b/unit_tests/test_storing_paths.py
@@ -1,6 +1,11 @@
 from trashcli.put import TrashDirectoryForPut
-from nose.tools import assert_equals
-from mock import Mock
+from nose.tools import assert_equal
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 class TestHowOriginalLocationIsStored:
     def test_for_absolute_paths(self):
@@ -26,4 +31,4 @@ class TestHowOriginalLocationIsStored:
 
     def assert_path_for_trashinfo_is(self, expected_value, file_to_be_trashed):
         result = self.dir.path_for_trash_info.for_file(file_to_be_trashed)
-        assert_equals(expected_value, result)
+        assert_equal(expected_value, result)

--- a/unit_tests/test_trash_dirs_listing.py
+++ b/unit_tests/test_trash_dirs_listing.py
@@ -2,7 +2,12 @@
 
 from trashcli.trash import TrashDirs
 from nose.tools import istest, assert_in, assert_not_in
-from mock import Mock
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 @istest
 class TestTrashDirs_listing:
@@ -72,8 +77,14 @@ class TestTrashDirs_listing:
 
 def not_important_for_now(): None
 
-from nose.tools import assert_equals
-from mock import MagicMock
+from nose.tools import assert_equal
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
 from trashcli.trash import TopTrashDirRules
 @istest
 class Describe_AvailableTrashDirs_when_parent_is_unsticky:
@@ -104,7 +115,7 @@ class Describe_AvailableTrashDirs_when_parent_is_unsticky:
 
         self.dirs.list_trashdirs()
 
-        assert_equals([], self.dirs.on_trashdir_skipped_because_parent_not_sticky.mock_calls)
+        assert_equal([], self.dirs.on_trashdir_skipped_because_parent_not_sticky.mock_calls)
 
 @istest
 class Describe_AvailableTrashDirs_when_parent_is_symlink:

--- a/unit_tests/test_trash_put.py
+++ b/unit_tests/test_trash_put.py
@@ -21,7 +21,7 @@ class TrashPutTest:
             result=main_function()
             if result is not None:
                 self.exit_code=result
-        except SystemExit, e:
+        except SystemExit as e:
             self.exit_code = e.code
 
     def stderr_should_be(self, expected_err):

--- a/unit_tests/test_trash_put.py
+++ b/unit_tests/test_trash_put.py
@@ -2,8 +2,14 @@
 
 from trashcli.put import TrashPutCmd
 
-from nose.tools import istest, assert_in, assert_equals
-from StringIO import StringIO
+from nose.tools import istest, assert_in, assert_equal
+
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 from integration_tests.assert_equals_with_unidiff import assert_equals_with_unidiff
 from textwrap import dedent
 
@@ -44,7 +50,7 @@ class TestWhenNoArgs(TrashPutTest):
         assert_line_in_text('Usage: trash-put [OPTION]... FILE...',
                             self.stderr.getvalue())
     def test_exit_code_should_be_not_zero(self):
-        assert_equals(2, self.exit_code)
+        assert_equal(2, self.exit_code)
 
 
 def assert_line_in_text(expected_line, text):

--- a/unit_tests/test_trash_put_reporter.py
+++ b/unit_tests/test_trash_put_reporter.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 from nose.tools import istest
 from trashcli.put import TrashPutReporter
 
@@ -7,8 +7,8 @@ class TestTrashPutReporter:
     def it_should_record_failures(self):
 
         reporter = TrashPutReporter()
-        assert_equals(False, reporter.some_file_has_not_be_trashed)
+        assert_equal(False, reporter.some_file_has_not_be_trashed)
 
         reporter.unable_to_trash_file('a file')
-        assert_equals(True, reporter.some_file_has_not_be_trashed)
+        assert_equal(True, reporter.some_file_has_not_be_trashed)
 

--- a/unit_tests/test_trash_rm.py
+++ b/unit_tests/test_trash_rm.py
@@ -1,5 +1,16 @@
-from nose.tools import istest, assert_items_equal
-from mock import Mock, call
+from nose.tools import istest
+
+# Try Python 2 import; if ImportError occurs, use Python 3 import
+try:
+    from nose.tools import assert_items_equal
+except ImportError:
+    from nose.tools import assert_count_equal as assert_items_equal
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock, call
+except ImportError:
+    from mock import Mock, call
 
 from trashcli.rm import Filter
 

--- a/unit_tests/test_trashdir.py
+++ b/unit_tests/test_trashdir.py
@@ -1,13 +1,13 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 from trashcli.trash import TrashDir
 from trashcli.trash import TrashDirectory
 
 class TestTrashDir:
     def test_path(self):
         trash_dir = TrashDirectory('/Trash-501', '/')
-        assert_equals('/Trash-501', trash_dir.path)
+        assert_equal('/Trash-501', trash_dir.path)
 
 class TestTrashDir_finding_orphans:
     def test(self):
@@ -15,14 +15,14 @@ class TestTrashDir_finding_orphans:
 
         self.find_orphan()
 
-        assert_equals([], self.orphan_found)
+        assert_equal([], self.orphan_found)
 
     def test2(self):
         self.fs.create_fake_file('/files/foo')
 
         self.find_orphan()
 
-        assert_equals(['/files/foo'], self.orphan_found)
+        assert_equal(['/files/foo'], self.orphan_found)
 
     def setUp(self):
         self.orphan_found=[]
@@ -55,15 +55,15 @@ class TestFakeFileSystem:
         self.fs = FakeFileSystem()
     def test_you_can_read_from_files(self):
         self.fs.create_fake_file('/path/to/file', "file contents")
-        assert_equals('file contents', self.fs.contents_of('/path/to/file'))
+        assert_equal('file contents', self.fs.contents_of('/path/to/file'))
     def test_when_creating_a_fake_file_it_creates_also_the_dir(self):
         self.fs.create_fake_file('/dir/file')
-        assert_equals(set(('file',)), set(self.fs.entries_if_dir_exists('/dir')))
+        assert_equal(set(('file',)), set(self.fs.entries_if_dir_exists('/dir')))
     def test_you_can_create_multiple_fake_file(self):
         self.fs.create_fake_file('/path/to/file1', "one")
         self.fs.create_fake_file('/path/to/file2', "two")
-        assert_equals('one', self.fs.contents_of('/path/to/file1'))
-        assert_equals('two', self.fs.contents_of('/path/to/file2'))
+        assert_equal('one', self.fs.contents_of('/path/to/file1'))
+        assert_equal('two', self.fs.contents_of('/path/to/file2'))
     def test_no_file_exists_at_beginning(self):
         assert not self.fs.exists('/filename')
     def test_after_a_creation_the_file_exists(self):
@@ -72,6 +72,6 @@ class TestFakeFileSystem:
     def test_create_fake_dir(self):
         self.fs.create_fake_dir('/etc', 'passwd', 'shadow', 'hosts')
 
-        assert_equals(set(['passwd', 'shadow', 'hosts']),
+        assert_equal(set(['passwd', 'shadow', 'hosts']),
                       set(self.fs.entries_if_dir_exists('/etc')))
 

--- a/unit_tests/test_trashdirs_how_to_list_them.py
+++ b/unit_tests/test_trashdirs_how_to_list_them.py
@@ -1,6 +1,12 @@
 from trashcli.trash import TrashDirs
-from mock import Mock, call
-from nose.tools import assert_equals
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock, call
+except ImportError:
+    from mock import Mock, call
+
+from nose.tools import assert_equal
 
 class TestListTrashinfo:
     def test_howto_list_trashdirs(self):
@@ -15,7 +21,7 @@ class TestListTrashinfo:
         trashdirs.on_trash_dir_found = out
         trashdirs.list_trashdirs()
 
-        assert_equals([call('/home/user/.local/share/Trash', '/'),
+        assert_equal([call('/home/user/.local/share/Trash', '/'),
                        call('/vol/.Trash-123', '/vol'),
                        call('/vol2/.Trash-123', '/vol2')],
                       out.mock_calls)

--- a/unit_tests/test_trashing_a_file.py
+++ b/unit_tests/test_trashing_a_file.py
@@ -1,7 +1,11 @@
 from trashcli.put import TrashDirectoryForPut
-from mock import Mock
 from nose.tools import istest
-from mock import ANY
+
+# Try Python 3 import; if ImportError occurs, use Python 2 import
+try:
+    from unittest.mock import Mock, ANY
+except ImportError:
+    from mock import Mock, ANY
 
 class TestTrashing:
     def setUp(self):

--- a/unit_tests/test_volume_of.py
+++ b/unit_tests/test_volume_of.py
@@ -1,6 +1,6 @@
 from trashcli.fstab import VolumeOf
 from trashcli.fstab import FakeIsMount
-from nose.tools import assert_equals, istest
+from nose.tools import assert_equal, istest
 import os
 
 @istest
@@ -14,15 +14,15 @@ class TestVolumeOf:
     @istest
     def return_the_containing_volume(self):
         self.ismount.add_mount('/fake-vol')
-        assert_equals('/fake-vol', self.volume_of('/fake-vol/foo'))
+        assert_equal('/fake-vol', self.volume_of('/fake-vol/foo'))
 
     @istest
     def with_file_that_are_outside(self):
         self.ismount.add_mount('/fake-vol')
-        assert_equals('/', self.volume_of('/foo'))
+        assert_equal('/', self.volume_of('/foo'))
 
     @istest
     def it_work_also_with_relative_mount_point(self):
         self.ismount.add_mount('relative-fake-vol')
-        assert_equals('relative-fake-vol', self.volume_of('relative-fake-vol/foo'))
+        assert_equal('relative-fake-vol', self.volume_of('relative-fake-vol/foo'))
 


### PR DESCRIPTION
Both Python 2 and Python 3 compatible code, tested with Python 2.7 and Python 3.4 in Fedora 22. It should work with Python 2.6 and 2.7 as well as with Python 3.2 and higher.
