### PR TITLE
Fix inconsistent apostrophes/quotation marks

### DIFF
--- a/integration_tests/test_file_descriptions.py
+++ b/integration_tests/test_file_descriptions.py
@@ -17,13 +17,13 @@ class TestDescritions:
 
     def test_on_dot_directories(self):
 
-        assert_equals("`.' directory",  describe("sandbox/."))
-        assert_equals("`.' directory",  describe("./."))
+        assert_equals("'.' directory",  describe("sandbox/."))
+        assert_equals("'.' directory",  describe("./."))
 
     def test_on_dot_dot_directories(self):
 
-        assert_equals("`..' directory", describe("./.."))
-        assert_equals("`..' directory", describe("sandbox/.."))
+        assert_equals("'..' directory", describe("./.."))
+        assert_equals("'..' directory", describe("sandbox/.."))
 
     def test_name_for_regular_files_non_empty_files(self):
 

--- a/integration_tests/test_trash_put.py
+++ b/integration_tests/test_trash_put.py
@@ -66,7 +66,7 @@ class when_deleting_an_existing_file_in_verbose_mode(TrashPutTest):
 
     @istest
     def should_tell_where_a_file_is_trashed(self):
-        assert_in("trash-put: `sandbox/foo' trashed in sandbox/XDG_DATA_HOME/Trash",
+        assert_in("trash-put: 'sandbox/foo' trashed in sandbox/XDG_DATA_HOME/Trash",
                   self.stderr.splitlines())
 
     @istest
@@ -96,7 +96,7 @@ class when_fed_with_dot_arguments(TrashPutTest):
         # the dot directory shouldn't be operated, but a diagnostic message
         # shall be writtend on stderr
         self.stderr_should_be(
-                "trash-put: cannot trash directory `.'\n")
+                "trash-put: cannot trash directory '.'\n")
 
         # the remaining arguments should be processed
         assert not exists('other_argument')
@@ -108,7 +108,7 @@ class when_fed_with_dot_arguments(TrashPutTest):
         # the dot directory shouldn't be operated, but a diagnostic message
         # shall be writtend on stderr
         self.stderr_should_be(
-            "trash-put: cannot trash directory `..'\n")
+            "trash-put: cannot trash directory '..'\n")
 
         # the remaining arguments should be processed
         assert not exists('other_argument')
@@ -120,7 +120,7 @@ class when_fed_with_dot_arguments(TrashPutTest):
         # the dot directory shouldn't be operated, but a diagnostic message
         # shall be writtend on stderr
         self.stderr_should_be(
-            "trash-put: cannot trash `.' directory `sandbox/.'\n")
+            "trash-put: cannot trash '.' directory 'sandbox/.'\n")
 
         # the remaining arguments should be processed
         assert not exists('other_argument')
@@ -133,7 +133,7 @@ class when_fed_with_dot_arguments(TrashPutTest):
         # the dot directory shouldn't be operated, but a diagnostic message
         # shall be writtend on stderr
         self.stderr_should_be(
-            "trash-put: cannot trash `..' directory `sandbox/..'\n")
+            "trash-put: cannot trash '..' directory 'sandbox/..'\n")
 
         # the remaining arguments should be processed
         assert not exists('other_argument')

--- a/trashcli/put.py
+++ b/trashcli/put.py
@@ -94,7 +94,7 @@ class TrashPutCmd:
         return parser
 
 epilog="""\
-To remove a file whose name starts with a `-', for example `-foo',
+To remove a file whose name starts with a '-', for example '-foo',
 use one of these commands:
 
     trash -- -foo
@@ -136,12 +136,12 @@ class TrashPutReporter:
         self.some_file_has_not_be_trashed = False
         self.no_argument_specified = False
     def unable_to_trash_dot_entries(self,file):
-        self.logger.warning("cannot trash %s `%s'" % (describe(file), file))
+        self.logger.warning("cannot trash %s '%s'" % (describe(file), file))
     def unable_to_trash_file(self,f):
-        self.logger.warning("cannot trash %s `%s'" % (describe(f), f))
+        self.logger.warning("cannot trash %s '%s'" % (describe(f), f))
         self.some_file_has_not_be_trashed = True
     def file_has_been_trashed_in_as(self, trashee, trash_directory, destination):
-        self.logger.info("`%s' trashed in %s" % (trashee,
+        self.logger.info("'%s' trashed in %s" % (trashee,
                                                  shrinkuser(trash_directory)))
     def found_unsercure_trash_dir_symlink(self, trash_dir_path):
         self.logger.info("found unsecure .Trash dir (should not be a symlink): %s"
@@ -169,8 +169,8 @@ def describe(path):
     Options:
      - "symbolic link"
      - "directory"
-     - "`.' directory"
-     - "`..' directory"
+     - "'.' directory"
+     - "'..' directory"
      - "regular file"
      - "regular empty file"
      - "non existent"
@@ -185,9 +185,9 @@ def describe(path):
             return 'directory'
         else:
             if os.path.basename(path) == '.':
-                return "`.' directory"
+                return "'.' directory"
             elif os.path.basename(path) == '..':
-                return "`..' directory"
+                return "'..' directory"
             else:
                 return 'directory'
     elif os.path.isfile(path):

--- a/unit_tests/test_trash_put.py
+++ b/unit_tests/test_trash_put.py
@@ -80,7 +80,7 @@ class describe_TrashPutCmd(TrashPutTest):
               -r, -R, --recursive  ignored (for GNU rm compatibility)
               -v, --verbose        explain what is being done
 
-            To remove a file whose name starts with a `-', for example `-foo',
+            To remove a file whose name starts with a '-', for example '-foo',
             use one of these commands:
 
                 trash -- -foo
@@ -93,12 +93,12 @@ class describe_TrashPutCmd(TrashPutTest):
     @istest
     def it_should_skip_dot_entry(self):
         self.run('.')
-        self.stderr_should_be("trash-put: cannot trash directory `.'\n")
+        self.stderr_should_be("trash-put: cannot trash directory '.'\n")
 
     @istest
     def it_should_skip_dotdot_entry(self):
         self.run('..')
-        self.stderr_should_be("trash-put: cannot trash directory `..'\n")
+        self.stderr_should_be("trash-put: cannot trash directory '..'\n")
 
     @istest
     def it_should_print_usage_on_no_argument(self):


### PR DESCRIPTION
When trashing a file that does not exist, the warning message puts a **tick** and an **apostrophe** around the file name. It should be two apostrophes. 

This issue I found at several places. This PR fixes that.

```sh
% trash no_file
trash: cannot trash non existent `no_file'
```