### PR TITLE
Refactor: except ... as

### DIFF
--- a/trashcli/put.py
+++ b/trashcli/put.py
@@ -53,7 +53,7 @@ class TrashPutCmd:
 
             if len(args) <= 0:
                 parser.error("Please specify the files to trash.")
-        except SystemExit,e:
+        except SystemExit as e:
             return e.code
         else:
             reporter = TrashPutReporter(logger)
@@ -284,7 +284,7 @@ class GlobalTrashCan:
                             trashed_file['where_file_was_stored'])
                         file_has_been_trashed = True
 
-                    except (IOError, OSError), error:
+                    except (IOError, OSError) as error:
                         self.reporter.unable_to_trash_file_in_because(
                                 file, trash_dir.path, str(error))
 

--- a/trashcli/trash.py
+++ b/trashcli/trash.py
@@ -94,7 +94,7 @@ class Parser:
             options, arguments = getopt(argv[1:],
                                         self.short_options,
                                         self.long_options)
-        except GetoptError, e:
+        except GetoptError as e:
             invalid_option = e.opt
             self._on_invalid_option(program_name, invalid_option)
         else:


### PR DESCRIPTION
Refactoring to cover the both Python 2 and Python 3 functionality in future - conversion from `except E , N:` to `except E as N:` ([PEP 3110](https://www.python.org/dev/peps/pep-3110/)).