### PR TITLE
Refactor: tabs replaced by spaces

### DIFF
--- a/trashcli/list_mount_points.py
+++ b/trashcli/list_mount_points.py
@@ -2,7 +2,7 @@
 
 def mount_points():
     try:
-	return list(mount_points_from_getmnt())
+        return list(mount_points_from_getmnt())
     except AttributeError:
         return mount_points_from_df()
 
@@ -17,14 +17,14 @@ def mount_points_from_df():
 
 def _mount_points_from_df_output(df_output):
     def skip_header():
-	df_output.readline()
+        df_output.readline()
     def chomp(string):
-	return string.rstrip('\n')
+        return string.rstrip('\n')
 
     skip_header()
     for line in df_output:
-	line = chomp(line)
-	yield line.split(None, 5)[-1]
+        line = chomp(line)
+        yield line.split(None, 5)[-1]
 
 def _mounted_filesystems_from_getmnt() :
     from ctypes import Structure, c_char_p, c_int, c_void_p, cdll, POINTER

--- a/unit_tests/test_list_mount_points.py
+++ b/unit_tests/test_list_mount_points.py
@@ -7,35 +7,35 @@ from trashcli.list_mount_points import _mount_points_from_df_output
 class MountPointFromDirTest(unittest.TestCase):
 
     def test_should_skip_the_first_line(self):
-	mount_points = _mount_points_from_df_output(StringIO.StringIO(
-	'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
-	))
+        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
+        ))
 
-	self.assertEquals([], list(mount_points))
+        self.assertEquals([], list(mount_points))
 
     def test_should_return_the_first_mount_point(self):
-	mount_points = _mount_points_from_df_output(StringIO.StringIO(
-	'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
-	'/dev/disk0s2         243862672 121934848 121671824      51% /\n'
-	))
+        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
+        '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
+        ))
 
-	self.assertEquals(['/'], list(mount_points))
+        self.assertEquals(['/'], list(mount_points))
 
     def test_should_return_multiple_mount_point(self):
-	mount_points = _mount_points_from_df_output(StringIO.StringIO(
-	'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
-	'/dev/disk0s2         243862672 121934848 121671824      51% /\n'
-	'/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/DISK\n'
-	))
+        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
+        '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
+        '/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/DISK\n'
+        ))
 
-	self.assertEquals(['/', '/Volumes/DISK'], list(mount_points))
+        self.assertEquals(['/', '/Volumes/DISK'], list(mount_points))
 
     def test_should_return_mount_point_with_white_spaces(self):
-	mount_points = _mount_points_from_df_output(StringIO.StringIO(
-	'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
-	'/dev/disk0s2         243862672 121934848 121671824      51% /\n'
-	'/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/with white spaces\n'
-	))
+        mount_points = _mount_points_from_df_output(StringIO.StringIO(
+        'Filesystem         1024-blocks      Used Available Capacity Mounted on\n'
+        '/dev/disk0s2         243862672 121934848 121671824      51% /\n'
+        '/dev/disk1s1         156287996 123044260  33243736      79% /Volumes/with white spaces\n'
+        ))
 
-	self.assertEquals(['/', '/Volumes/with white spaces'], list(mount_points))
+        self.assertEquals(['/', '/Volumes/with white spaces'], list(mount_points))
 


### PR DESCRIPTION
Refactoring to cover the both Python 2 and Python 3 functionality in future - tab converted to spaces for indentation ([PEP 8](https://www.python.org/dev/peps/pep-0008/)).