### PR TITLE
Refactor: octal literals

### DIFF
--- a/trashcli/fs.py
+++ b/trashcli/fs.py
@@ -55,7 +55,7 @@ def mkdirs(path):
 
 def atomic_write(filename, content):
     file_handle = os.open(filename, os.O_RDWR | os.O_CREAT | os.O_EXCL,
-            0600)
+            0o600)
     os.write(file_handle, content)
     os.close(file_handle)
 

--- a/trashcli/put.py
+++ b/trashcli/put.py
@@ -426,7 +426,7 @@ class TrashDirectoryForPut:
         return content
 
     def ensure_files_dir_exists(self):
-        self.ensure_dir(self.files_dir, 0700)
+        self.ensure_dir(self.files_dir, 0o700)
 
     def persist_trash_info(self, info_dir, basename, content) :
         """
@@ -434,7 +434,7 @@ class TrashDirectoryForPut:
         returns the created TrashInfoFile.
         """
 
-        self.ensure_dir(info_dir, 0700)
+        self.ensure_dir(info_dir, 0o700)
 
         # write trash info
         index = 0


### PR DESCRIPTION
Refactoring to cover the both Python 2 and Python 3 functionality in future - octal literals are specified with a leading `0o` ([PEP 3127](https://www.python.org/dev/peps/pep-3127/)).