### PR TITLE
Refactor: absolute/relative import

### DIFF
--- a/integration_tests/describe_trash_list.py
+++ b/integration_tests/describe_trash_list.py
@@ -2,19 +2,19 @@
 
 import os
 from trashcli.list import ListCmd
-from files import (write_file, require_empty_dir, make_sticky_dir,
+from .files import (write_file, require_empty_dir, make_sticky_dir,
                    make_unsticky_dir, make_unreadable_file, make_empty_file,
                    make_parent_for)
 from nose.tools import istest
 from .output_collector import OutputCollector
-from trashinfo import (
+from .trashinfo import (
         a_trashinfo,
         a_trashinfo_without_date,
         a_trashinfo_without_path,
         a_trashinfo_with_invalid_date)
 from textwrap import dedent
 
-from assert_equals_with_unidiff import assert_equals_with_unidiff
+from .assert_equals_with_unidiff import assert_equals_with_unidiff
 class Setup(object):
     def setUp(self):
         require_empty_dir('XDG_DATA_HOME')

--- a/integration_tests/output_collector.py
+++ b/integration_tests/output_collector.py
@@ -1,4 +1,4 @@
-from assert_equals_with_unidiff import assert_equals_with_unidiff
+from .assert_equals_with_unidiff import assert_equals_with_unidiff
 
 class OutputCollector:
     def __init__(self):

--- a/integration_tests/test_listing_all_trashinfo_in_a_trashdir.py
+++ b/integration_tests/test_listing_all_trashinfo_in_a_trashdir.py
@@ -1,7 +1,7 @@
 from trashcli.trash import TrashDirectory
 
-from files import require_empty_dir
-from files import write_file
+from .files import require_empty_dir
+from .files import write_file
 from nose.tools import assert_equals, assert_items_equal
 from mock import Mock
 

--- a/integration_tests/test_restore_trash.py
+++ b/integration_tests/test_restore_trash.py
@@ -4,7 +4,7 @@ from trashcli.restore import RestoreCmd
 
 from .files import require_empty_dir
 from .output_collector import OutputCollector
-from trashinfo import a_trashinfo
+from .trashinfo import a_trashinfo
 
 @istest
 class describe_restore_trash:

--- a/integration_tests/test_trash_empty.py
+++ b/integration_tests/test_trash_empty.py
@@ -7,8 +7,8 @@ from trashcli.empty import EmptyCmd
 
 from StringIO import StringIO
 import os
-from files import write_file, require_empty_dir, make_dirs, set_sticky_bit
-from files import having_file
+from .files import write_file, require_empty_dir, make_dirs, set_sticky_bit
+from .files import having_file
 from mock import MagicMock
 from trashcli.trash import FileSystemReader
 from trashcli.fs import FileRemover

--- a/integration_tests/test_trash_rm.py
+++ b/integration_tests/test_trash_rm.py
@@ -2,9 +2,9 @@ from StringIO import StringIO
 from mock import Mock, ANY
 from nose.tools import assert_false, assert_raises, assert_equals
 
-from files import require_empty_dir, write_file
+from .files import require_empty_dir, write_file
 from trashcli.rm import RmCmd, ListTrashinfos
-from trashinfo import a_trashinfo_with_path, a_trashinfo_without_path
+from .trashinfo import a_trashinfo_with_path, a_trashinfo_without_path
 from trashcli.trash import ParseError
 
 class TestTrashRm:

--- a/integration_tests/test_trash_rm_script.py
+++ b/integration_tests/test_trash_rm_script.py
@@ -1,7 +1,7 @@
 from nose.tools import istest, assert_equals, assert_in
 import subprocess
 from subprocess import STDOUT, PIPE, check_output, call, Popen
-from assert_equals_with_unidiff import assert_equals_with_unidiff as assert_equals
+from .assert_equals_with_unidiff import assert_equals_with_unidiff as assert_equals
 from textwrap import dedent
 
 from pprint import pprint

--- a/trashcli/restore.py
+++ b/trashcli/restore.py
@@ -7,7 +7,7 @@ from .trash import TrashDirectory
 from .trash import TrashDirectories
 from .fs import contents_of
 from .trash import backup_file_path_from
-import fs
+from . import fs
 
 def getcwd_as_realpath(): return os.path.realpath(os.curdir)
 


### PR DESCRIPTION
Refactoring to cover the both Python 2 and Python 3 functionality in future - absolute/relative import according to [PEP 328](https://www.python.org/dev/peps/pep-0328/).