### PR TITLE
Refactoring: open() replaces file()

### DIFF
--- a/integration_tests/files.py
+++ b/integration_tests/files.py
@@ -14,7 +14,7 @@ make_empty_file = having_file
 def write_file(filename, contents=''):
     parent = os.path.dirname(filename)
     if not os.path.isdir(parent): os.makedirs(parent)
-    file(filename, 'w').write(contents)
+    open(filename, 'w').write(contents)
     assert_equals(file(filename).read(), contents)
 
 def require_empty_dir(path):
@@ -73,5 +73,5 @@ def make_unreadable_file(path):
     os.chmod(path, 0)
     from nose.tools import assert_raises
     with assert_raises(IOError):
-        file(path).read()
+        open(path).read()
 

--- a/integration_tests/test_persist.py
+++ b/integration_tests/test_persist.py
@@ -55,5 +55,5 @@ class TestTrashDirectory_persit_trash_info:
     test_persist_trash_info_other_times.stress_test = True
 
 def read(path):
-    return file(path).read()
+    return open(path).read()
 

--- a/integration_tests/test_restore_trash.py
+++ b/integration_tests/test_restore_trash.py
@@ -71,7 +71,7 @@ class describe_restore_trash:
     def it_should_refuse_overwriting_existing_file(self):
 
         self.having_a_file_trashed_from_current_dir('foo')
-        file('foo', 'a+').close()
+        open('foo', 'a+').close()
         os.chmod('foo', 000)
         self.when_running_restore_trash(from_dir=current_dir(),
                                         with_user_typing = '0')

--- a/integration_tests/test_trash_put.py
+++ b/integration_tests/test_trash_put.py
@@ -104,7 +104,7 @@ class when_deleting_an_existing_file(TrashPutTest):
 
     @istest
     def a_trashinfo_file_should_have_been_created(self):
-        file('sandbox/XDG_DATA_HOME/Trash/info/foo.trashinfo').read()
+        open('sandbox/XDG_DATA_HOME/Trash/info/foo.trashinfo').read()
 
 @istest
 class when_deleting_an_existing_file_in_verbose_mode(TrashPutTest):

--- a/trashcli/fs.py
+++ b/trashcli/fs.py
@@ -15,7 +15,7 @@ class FileSystemReader(FileSystemListing):
     def is_symlink(self, path):
         return os.path.islink(path)
     def contents_of(self, path):
-        return file(path).read()
+        return open(path).read()
 
 class FileRemover:
     def remove_file(self, path):

--- a/unit_tests/test_restore_cmd.py
+++ b/unit_tests/test_restore_cmd.py
@@ -84,8 +84,8 @@ class TestTrashRestoreCmd:
         from trashcli.fs import remove_file
         from trashcli.fs import contents_of
         self.user_reply = '0'
-        file('orig_file', 'w').write('original')
-        file('info_file', 'w').write('')
+        open('orig_file', 'w').write('original')
+        open('info_file', 'w').write('')
         remove_file('parent/path')
         remove_file('parent')
 
@@ -222,7 +222,7 @@ class TestRestoreCmdListingIntegration:
     def test_something(self):
         cmd = RestoreCmd(None, None, {}, None, None)
         require_empty_dir('info')
-        file('info/info_path.trashinfo', 'w').write(
+        open('info/info_path.trashinfo', 'w').write(
                 'Path=name\nDeletionDate=2001-01-01T10:10:10')
         path_to_trashinfo = 'info/info_path.trashinfo'
         trash_dir = Mock([])


### PR DESCRIPTION
Refactoring to cover the both Python 2 and Python 3 functionality in future - `open()` is a preferable way instead of `file()` that has been removed from Python 3.