### PR TITLE
Fix: raw_input is replaced by input in Python 3

### DIFF
--- a/trashcli/cmds.py
+++ b/trashcli/cmds.py
@@ -4,12 +4,16 @@ import sys,os
 
 def restore():
     from trashcli.restore import RestoreCmd
+    try:           # Python 2
+        input23 = raw_input
+    except:        # Python 3
+        input23 = input
     RestoreCmd(
         stdout  = sys.stdout,
         stderr  = sys.stderr,
         environ = os.environ,
         exit    = sys.exit,
-        input   = raw_input
+        input   = input23
     ).run(sys.argv)
 
 def empty(argv    = sys.argv,


### PR DESCRIPTION
The commit fixes a following error in Python 3 according to [PEP 3111](https://www.python.org/dev/peps/pep-3111/):
```
$ ./trash-restore foo
Traceback (most recent call last):
  File "./trash-restore", line 5, in <module>
    sys.exit(main())
  File "/home/jberan/git/trash-cli/trashcli/cmds.py", line 12, in restore
    input   = raw_input
NameError: name 'raw_input' is not defined
```
