### PR TITLE
Fix minor spelling mistake in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ The easy way
 
 Requirements:
 
- - Python 2.7 o Python 3
+ - Python 2.7 or Python 3
  - setuptools (use `apt-get install python-setuptools` on Debian)
 
 Installation command::


### PR DESCRIPTION
This commit changes an `o` to `or` in the readme.