### PR TITLE
'trash-put -f' now ignores absent files/directories, similar to 'rm -f'.

### DIFF
--- a/man/man1/trash-put.1
+++ b/man/man1/trash-put.1
@@ -22,7 +22,9 @@ trash-put \- Command line trash utility.
 
 .SH "SYNOPSIS"
 .B trash-put
-.RI [ arguments ]
+.RI [ OPTION ] 
+\&...
+.RI [ ARGUMENTS ]
 \&...
 
 .SH "DESCRIPTION"
@@ -35,6 +37,25 @@ each trashed file.
 .SH "ARGUMENTS"
 .TP
 Names of files or directories to move in the trashcan.
+
+.SH "OPTIONS"
+.IP "-f"
+.br
+Silently ignore any files or directories that do not exist.
+Do not print error messages, and do not return a nonzero status
+to the caller, because of any such nonexistent arguments.
+
+.IP "-h, --help"
+Show help message and exit.
+
+.IP "--trash-dir=TRASHDIR"
+Use TRASHDIR as trash folder.
+
+.IP "-v, --verbose"
+Explain what is being done.
+
+.IP "--version"
+Show program's version number and exit.
 
 .SH "EXAMPLES"
 .nf

--- a/trashcli/put.py
+++ b/trashcli/put.py
@@ -65,6 +65,7 @@ class TrashPutCmd:
             if options.trashdir:
                 self.trashdir = options.trashdir
 
+            self.ignore_missing = options.ignore_missing
             self.reporter = TrashPutReporter(logger)
             self.logger = trash_logger
             self.trash_all(args)
@@ -94,7 +95,8 @@ Report bugs to https://github.com/andreafrancia/trash-cli/issues""")
                           help="ignored (for GNU rm compatibility)")
         parser.add_option("-f", "--force",
                           action="store_true",
-                          help="ignored (for GNU rm compatibility)")
+                          dest="ignore_missing",
+                          help="silently ignore nonexistent files")
         parser.add_option("-i", "--interactive",
                           action="store_true",
                           help="ignored (for GNU rm compatibility)")
@@ -148,6 +150,9 @@ Report bugs to https://github.com/andreafrancia/trash-cli/issues""")
 
         if self._should_skipped_by_specs(file):
             self.reporter.unable_to_trash_dot_entries(file)
+            return
+
+        if self.ignore_missing and not os.access(file, os.F_OK):
             return
 
         volume_of_file_to_be_trashed = self.volume_of_parent(file)
@@ -269,6 +274,7 @@ class GlobalTrashCan(TrashPutCmd):
         self.parent_path       = parent_path
         self.realpath          = realpath
         self.logger            = logger
+        self.ignore_missing    = False
 
 def describe(path):
     """

--- a/unit_tests/test_trash_put.py
+++ b/unit_tests/test_trash_put.py
@@ -119,7 +119,7 @@ class TestTrashPutCmd(TrashPutTest):
               --version             show program's version number and exit
               -h, --help            show this help message and exit
               -d, --directory       ignored (for GNU rm compatibility)
-              -f, --force           ignored (for GNU rm compatibility)
+              -f, --force           silently ignore nonexistent files
               -i, --interactive     ignored (for GNU rm compatibility)
               -r, -R, --recursive   ignored (for GNU rm compatibility)
               --trash-dir=TRASHDIR  use TRASHDIR as trash folder
@@ -149,5 +149,10 @@ class TestTrashPutCmd(TrashPutTest):
             'Usage: trash-put [OPTION]... FILE...\n'
             '\n'
             'trash-put: error: Please specify the files to trash.\n')
+        self.stdout_should_be('')
+
+    def test_it_should_skip_missing_files(self):
+        self.run('-f', 'this_file_does_not_exist', 'nor_does_this_file')
+        self.stderr_should_be('')
         self.stdout_should_be('')
 


### PR DESCRIPTION
As a user of `trash-put` in writing scripts that run automatically, I wanted the convenience of the `-f` option to ignore missing files or directories without generating an error. This is especially important when the script checks the return value from executing `trash-put`. If I don't care that a trashed file does not exist, I don't want my script to think something failed.

* I implemented `trash-put -f`.
* I added a unit test to exercise this option. The code passes all 208 tests in `nosetests`.
* I updated the help text printed by `trash-put -h` and `trash-put --help`.
* I updated the man page viewed by executing `man trash-put` to document all options.

I am now using these changes on my own system. I thought others might benefit also.