### PR TITLE
trash-list: Show all partitions including not physical

### DIFF
--- a/trashcli/list_mount_points.py
+++ b/trashcli/list_mount_points.py
@@ -6,7 +6,7 @@ def main():
 
 def mount_points():
     import psutil
-    for p in psutil.disk_partitions():
+    for p in psutil.disk_partitions(all = True):
         yield p.mountpoint
 
 


### PR DESCRIPTION
Since v0.20.11.14, `trash-list` has come not to list trashed files in non-physical partitions (such as tmpfs).

However, `trash-put` can discard files in non-physical partitions.
Then, it is sadly out of trash-cli management: `trash-list` can't see it.

It is because of `psutil.disk_partitions()`'s default behavior:
show only physical devices only by default as `all = False`.

If this behavior is not strongly intended,
it should show non-physical partitions together as older versions until v0.20.11.7 had been doing.