### PR TITLE
Use 'date' as the default sort argument

### DIFF
--- a/trashcli/restore.py
+++ b/trashcli/restore.py
@@ -42,7 +42,7 @@ def parse_args(sys_argv, curdir):
                              'directory')
     parser.add_argument('--sort',
                         choices=['date', 'path', 'none'],
-                        default='path',
+                        default='date',
                         help='Sort list of restore candidates by given field')
     parser.add_argument('--trash-dir',
                         action='store',

--- a/unit_tests/test_restore_cmd.py
+++ b/unit_tests/test_restore_cmd.py
@@ -22,7 +22,7 @@ class Test_parse_args(unittest.TestCase):
         args = restore.parse_args(['', '/a/path'], None)
         self.assertEqual('/a/path', args.path)
         self.assertEqual(False, args.version)
-        self.assertEqual('path', args.sort)
+        self.assertEqual('date', args.sort)
 
     def test_show_version(self):
         args = restore.parse_args(['', '--version'], None)


### PR DESCRIPTION
This updates sorting to use the date argument by default as discusses in #168.

I feel that sorting by date is a more sane default since most users running `trash-restore` are likely attempting to restore files that were recently deleted.