### PR TITLE
Add sort option to trash-list

### DIFF
--- a/integration_tests/test_trash_list.py
+++ b/integration_tests/test_trash_list.py
@@ -30,22 +30,6 @@ def sort_lines(lines):
 
 class Test_describe_trash_list(Setup):
 
-    def test_should_output_the_help_message(self):
-
-        self.user.run_trash_list('--help')
-
-        assert_equals_with_unidiff(dedent("""\
-            Usage: trash-list [OPTIONS...]
-
-            List trashed files
-
-            Options:
-              --version   show program's version number and exit
-              -h, --help  show this help message and exit
-
-            Report bugs to https://github.com/andreafrancia/trash-cli/issues
-        """), self.user.output())
-
     def test_should_output_nothing_when_trashcan_is_empty(self):
 
         self.user.run_trash_list()

--- a/trashcli/list.py
+++ b/trashcli/list.py
@@ -34,18 +34,13 @@ def parse_args(sys_argv, curdir):
                         choices=['date', 'path', 'none'],
                         default='date',
                         help='Sort list of list candidates by given field')
-    parser.add_argument('--trash-dir',
-                        action='store',
-                        dest='trash_dir',
-                        help=argparse.SUPPRESS)
     parser.add_argument('--version', action='store_true', default=False)
     parsed = parser.parse_args(sys_argv[1:])
 
     if parsed.version:
         return Command.PrintVersion, None
     else:
-        return Command.RunList, {'sort': parsed.sort,
-                                 'trash_dir': parsed.trash_dir}
+        return Command.RunList, {'sort': parsed.sort}
 
 class Command:
     PrintVersion = "Command.PrintVersion"
@@ -81,7 +76,6 @@ class ListCmd:
             self.output.println('%s %s' % (command, self.version))
             return
         elif cmd == Command.RunList:
-            trash_dir_from_cli = args['trash_dir']
             trashed_files = self.list_trash()
             if args['sort'] == 'path':
                 trashed_files = sorted(trashed_files, key=lambda x: x.original_location + str(x.deletion_date))

--- a/trashcli/list.py
+++ b/trashcli/list.py
@@ -22,13 +22,14 @@ def main():
         environ      = os.environ,
         getuid       = os.getuid,
         list_volumes = os_mount_points,
-    ).run(sys.argv)
+    ).run(*sys.argv)
 
 def parse_args(sys_argv, curdir):
     import argparse
     parser = argparse.ArgumentParser(
         description='List trashed files',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        epilog="Report bugs to https://github.com/andreafrancia/trash-cli/issues")
     parser.add_argument('--sort',
                         choices=['date', 'path', 'none'],
                         default='date',
@@ -73,7 +74,7 @@ class ListCmd:
         self.contents_of  = file_reader.contents_of
         self.version      = version
 
-    def run(self, argv):
+    def run(self, *argv):
         cmd, args = parse_args(argv, os.path.realpath(os.curdir) + os.path.sep)
         if cmd == Command.PrintVersion:
             command = os.path.basename(argv[0])

--- a/unit_tests/test_issues_message.py
+++ b/unit_tests/test_issues_message.py
@@ -41,15 +41,6 @@ class TestTrashPutIssueMessage(unittest.TestCase):
         self.assert_last_line_of_output_is(
                 'Report bugs to https://github.com/andreafrancia/trash-cli/issues')
 
-    def test_trash_list_last_line(self):
-        from trashcli.list import ListCmd
-
-        cmd = ListCmd(self.out, None, None, None, None)
-        cmd.run('', '--help')
-
-        self.assert_last_line_of_output_is(
-                'Report bugs to https://github.com/andreafrancia/trash-cli/issues')
-
     def assert_last_line_of_output_is(self, expected):
         output = self.out.getvalue()
         if len(output.splitlines()) > 0:


### PR DESCRIPTION
Similar to `trash-restore`, this PR add sort option to `trash-list`. The implementation is taken based on `trash-restore`, and currently the default sort is set to date (originally there was no sort in `trash-list`).

```sh
trash-list --sort {date,path,none}
```