### PR TITLE
Fix unit tests not deleting temp directories

### DIFF
--- a/tests/empty/test_empty_end_to_end_interactive.py
+++ b/tests/empty/test_empty_end_to_end_interactive.py
@@ -40,3 +40,6 @@ class TestEmptyEndToEndInteractive(unittest.TestCase):
             'Would empty the following trash directories:\n'
             '    - %s\n'
             'Proceed? (y/n) ' % self.trash_dir, '', 0]
+
+    def tearDown(self):
+        self.tmp_dir.clean_up()

--- a/tests/empty/test_empty_end_to_end_with_argument.py
+++ b/tests/empty/test_empty_end_to_end_with_argument.py
@@ -54,3 +54,6 @@ class TestEmptyEndToEndWithArgument(unittest.TestCase):
         self.user_run_trash_empty(['2'])
 
         assert list_trash_dir(self.trash_dir) == ['info/foo.trashinfo']
+
+    def tearDown(self):
+        self.tmp_dir.clean_up()

--- a/tests/put/test_end_to_end_put.py
+++ b/tests/put/test_end_to_end_put.py
@@ -89,3 +89,6 @@ class TestEndToEndPut(unittest.TestCase):
                                          ['-f', 'this_file_does_not_exist', 'nor_does_this_file'])
 
         assert [result.stdout, result.stderr, result.exit_code] == ['', '', 0]
+
+    def tearDown(self):
+        self.tmp_dir.clean_up()

--- a/tests/restore/test_trash_directory.py
+++ b/tests/restore/test_trash_directory.py
@@ -53,4 +53,5 @@ class TestTrashDirectory(unittest.TestCase):
     def list_trashinfos(self):
         return list(self.trash_dir.all_info_files(self.temp_dir / 'trash-dir'))
 
-
+    def tearDown(self):
+        self.temp_dir.clean_up()

--- a/tests/support.py
+++ b/tests/support.py
@@ -34,4 +34,4 @@ class MyPath(str):
 
     @classmethod
     def make_temp_dir(cls):
-        return cls(os.path.realpath(tempfile.mkdtemp()))
+        return cls(os.path.realpath(tempfile.mkdtemp(suffix="_trash_cli_test")))

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -45,3 +45,4 @@ class Test_make_unreadable_dir(unittest.TestCase):
     def tearDown(self):
         make_readable(self.unreadable_dir)
         shutil.rmtree(self.unreadable_dir)
+        self.tmp_dir.clean_up()

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -64,3 +64,5 @@ class Test_is_sticky_dir(unittest.TestCase):
 
         assert not is_sticky_dir(self.temp_dir / 'dir')
 
+    def tearDown(self):
+        self.temp_dir.clean_up()

--- a/tests/test_trash_put_slow.py
+++ b/tests/test_trash_put_slow.py
@@ -29,6 +29,9 @@ class TrashPutFixture:
         self.stderr = result.stderr
         self.exit_code = result.exit_code
 
+    def __del__(self):
+        self.temp_dir.clean_up()
+
 
 @pytest.mark.slow
 class TestDeletingExistingFile(unittest.TestCase):


### PR DESCRIPTION
Some tests were not deleting temporary directories polluting /tmp. This
patch fixes all locations in the code where this was forgotten.

Additionally we apply a suffix on top of the randomly generated name for
the temp directories (new name example: tmpwl2fvrn9_trash_cli_test)
becasue:
- it has no cost to us or the users
- helps identify temporary directories as belonging to trash-cli tests
- will make similar issues obvious in the future

Bug: GH-218
