### PR TITLE
Fix lint

### DIFF
--- a/tests/empty/test_empty_end_to_end_interactive.py
+++ b/tests/empty/test_empty_end_to_end_interactive.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 
 from ..fake_trash_dir import FakeTrashDir
-from ..support import MyPath, list_trash_dir
+from ..support import MyPath
 from .. import run_command
 
 

--- a/tests/myStringIO.py
+++ b/tests/myStringIO.py
@@ -1,4 +1,0 @@
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO

--- a/tests/put/test_file_trasher.py
+++ b/tests/put/test_file_trasher.py
@@ -3,7 +3,7 @@ import unittest
 from mock import Mock
 from datetime import datetime
 
-from trashcli.put import TrashResult, Trasher, FileTrasher
+from trashcli.put import TrashResult, FileTrasher
 import os
 
 

--- a/tests/put/test_home_fallback.py
+++ b/tests/put/test_home_fallback.py
@@ -3,7 +3,7 @@ import unittest
 from mock import Mock, call, ANY
 
 from trashcli.fstab import create_fake_volume_of
-from trashcli.put import TrashResult, Trasher, TrashDirectoriesFinder, FileTrasher
+from trashcli.put import TrashResult, TrashDirectoriesFinder, FileTrasher
 from datetime import datetime
 import os
 

--- a/tests/test_restore_cmd.py
+++ b/tests/test_restore_cmd.py
@@ -3,7 +3,7 @@ import unittest
 from trashcli.list_mount_points import os_mount_points
 from trashcli.restore import RestoreCmd, make_trash_directories, \
     TrashDirectory, TrashedFiles, Command
-from .myStringIO import StringIO
+from six import StringIO
 from mock import call
 from trashcli import restore
 import datetime

--- a/tests/test_trash_rm.py
+++ b/tests/test_trash_rm.py
@@ -1,8 +1,6 @@
 import unittest
 
-import six
-
-from mock import Mock, call
+from mock import Mock
 
 from trashcli.rm import Filter
 from six import StringIO

--- a/trashcli/list.py
+++ b/trashcli/list.py
@@ -4,7 +4,7 @@ import os
 
 from . import fstab
 from .fs import FileSystemReader, file_size
-from .fstab import volume_of, VolumesListing
+from .fstab import VolumesListing
 from .trash import (version, TrashDirReader, path_of_backup_copy, print_version,
                     maybe_parse_deletion_date, trash_dir_found,
                     trash_dir_skipped_because_parent_is_symlink,


### PR DESCRIPTION
Running pylfakes reveals several QA issues with the code:

```
>>> pyflakes .
./tests/myStringIO.py:4:5 'io.StringIO' imported but unused
./tests/test_trash_rm.py:3:1 'six' imported but unused
./tests/test_trash_rm.py:5:1 'mock.call' imported but unused
./tests/empty/test_empty_end_to_end_interactive.py:7:1 '..support.list_trash_dir' imported but unused
./tests/put/test_file_trasher.py:6:1 'trashcli.put.Trasher' imported but unused
./tests/put/test_home_fallback.py:6:1 'trashcli.put.Trasher' imported but unused
./trashcli/list.py:7:1 '.fstab.volume_of' imported but unused
./trashcli/list.py:39:18 redefinition of unused 'volume_of' from line 7
./trashcli/list.py:131:59 redefinition of unused 'volume_of' from line 7
```

This PR will:
- Fix lint in tests
- Fix lint in trash-cli

Test plan:

```
>>> python -m unittest discover -v
...
----------------------------------------------------------------------
Ran 280 tests in 13.362s

OK
>>> pyflakes .
>>>
```
