### PR TITLE
fix: handle eof in restore input

### DIFF
--- a/trashcli/restore.py
+++ b/trashcli/restore.py
@@ -191,6 +191,8 @@ class RestoreAskingTheUser(object):
             user_input = self.input("What file to restore [0..%d]: " % (len(trashed_files) - 1))
         except KeyboardInterrupt:
             return self.die("")
+        except EOFError:
+            return self.die("")
         if user_input == "":
             self.println("Exiting")
         else:


### PR DESCRIPTION
This adds an exception case after the input line in `restore.py` so that the program exits gracefully if the user enters <kbd>Ctrl+D</kbd>.