### PR TITLE
Fix trash-empty not showing nfs mountpoints

### DIFF
--- a/trashcli/list_mount_points.py
+++ b/trashcli/list_mount_points.py
@@ -6,13 +6,17 @@ def main():
     for mp in os_mount_points():
         print(mp)
 
-
 def os_mount_points():
     import psutil
-    for p in psutil.disk_partitions():
-        if os.path.isdir(p.mountpoint):
-            yield p.mountpoint
+    # List of accepted non-physical fstypes
+    fstypes = ['nfs']
 
+    # Append fstypes of physicial devices to list
+    fstypes += set([p.fstype for p in psutil.disk_partitions()])
+
+    for p in psutil.disk_partitions(all=True):
+        if os.path.isdir(p.mountpoint) and p.fstype in fstypes:
+            yield p.mountpoint
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add 'nfs' fstype to listed mountpoints. Fixes #229 