### PR TITLE
Fix the unhandled exception 'FileNotFoundError' that occurs in 'trashcli.list.SizeExtractor.extract_attribute()'

### DIFF
--- a/trashcli/list.py
+++ b/trashcli/list.py
@@ -115,7 +115,13 @@ class DeletionDateExtractor:
 class SizeExtractor:
     def extract_attribute(self, trashinfo_path, _contents):
         backup_copy = path_of_backup_copy(trashinfo_path)
-        return str(file_size(backup_copy))
+        try:
+            return str(file_size(backup_copy))
+        except FileNotFoundError:
+            if os.path.islink(backup_copy):
+                return 0
+            else:
+                raise
 
 
 def description(program_name, printer):


### PR DESCRIPTION
This pull request fixes the unhandled exception `FileNotFoundError` that occurs in the method `trashcli.list.SizeExtractor.extract_attribute()`.

The command-line tool `trash-size` raises the exception `FileNotFoundError` when a broken symbolic link is in the Trash:
```
 Traceback (most recent call last):
  File "/home/user/.pyvenv/bin/trash-list", line 5, in <module>
    sys.exit(main())
  File "/home/user/.pyvenv/lib/python3.10/site-packages/trashcli/list.py", line 21, in main
    ListCmd(
  File "/home/user/.pyvenv/lib/python3.10/site-packages/trashcli/list.py", line 64, in run
    self.list_trash(parsed.trash_dirs, extractor, parsed.show_files)
  File "/home/user/.pyvenv/lib/python3.10/site-packages/trashcli/list.py", line 74, in list_trash
    self._print_trashinfo(volume, trash_info, extractor, show_files)
  File "/home/user/.pyvenv/lib/python3.10/site-packages/trashcli/list.py", line 93, in _print_trashinfo
    attribute = extractor.extract_attribute(trashinfo_path, contents)
  File "/home/user/.pyvenv/lib/python3.10/site-packages/trashcli/list.py", line 118, in extract_attribute
    return str(file_size(backup_copy))
  File "/home/user/.pyvenv/lib/python3.10/site-packages/trashcli/fs.py", line 96, in file_size
    return os.stat(path).st_size
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/.local/share/Trash/files/broken-link'
```
