### PR TITLE
Fix links to trash specification

### DIFF
--- a/docs/trashspec-0.7.html
+++ b/docs/trashspec-0.7.html
@@ -380,7 +380,7 @@ and contributors somewhere, and (b) indicate that this is a modified
 version.</P>
 <P>Implementation under any license at all is explicitly allowed.</P>
 <H3>Location</H3>
-<P><A HREF="http://www.ramendik.ru/docs/trashspec.html">http://www.ramendik.ru/docs/trashspec.html</A>
+<P><A HREF="https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html">https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html</A>
 . If this document gets hosted by FreeDesktop.org, a link to the page
 will still be available at this location.</P>
 <P><A HREF="http://www.ramendik.ru/docs/trashspec.0.7.html">http://www.ramendik.ru/docs/trashspec.0.5.html</A>

--- a/docs/trashspec-0.7.html
+++ b/docs/trashspec-0.7.html
@@ -380,7 +380,7 @@ and contributors somewhere, and (b) indicate that this is a modified
 version.</P>
 <P>Implementation under any license at all is explicitly allowed.</P>
 <H3>Location</H3>
-<P><A HREF="https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html">https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html</A>
+<P><A HREF="http://www.ramendik.ru/docs/trashspec.html">http://www.ramendik.ru/docs/trashspec.html</A>
 . If this document gets hosted by FreeDesktop.org, a link to the page
 will still be available at this location.</P>
 <P><A HREF="http://www.ramendik.ru/docs/trashspec.0.7.html">http://www.ramendik.ru/docs/trashspec.0.5.html</A>

--- a/man/man1/trash-empty.1
+++ b/man/man1/trash-empty.1
@@ -79,7 +79,7 @@ trash-list(1),
 trash-restore(1), 
 trash-rm(1),
 and the FreeDesktop.org Trash Specification at 
-http://www.ramendik.ru/docs/trashspec.html.
+https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html.
 .br
 
 Both are released under the \s-1GNU\s0 General Public License, version 2 or

--- a/man/man1/trash-list.1
+++ b/man/man1/trash-list.1
@@ -69,7 +69,7 @@ trash-restore(1),
 trash-empty(1),
 trash-rm(1),
 and the FreeDesktop.org Trash Specification at 
-http://www.ramendik.ru/docs/trashspec.html.
+https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html.
 .br
 
 Both are released under the \s-1GNU\s0 General Public License, version 2 or

--- a/man/man1/trash-put.1
+++ b/man/man1/trash-put.1
@@ -87,7 +87,7 @@ trash-restore(1),
 trash-empty(1),
 trash-rm(1),
 and the FreeDesktop.org Trash Specification at 
-http://www.ramendik.ru/docs/trashspec.html.
+https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html.
 .br
 
 Both are released under the \s-1GNU\s0 General Public License, 

--- a/man/man1/trash-restore.1
+++ b/man/man1/trash-restore.1
@@ -64,7 +64,7 @@ trash-list(1),
 trash-empty(1),
 trash-rm(1),
 and the FreeDesktop.org Trash Specification at 
-http://www.ramendik.ru/docs/trashspec.html.
+https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html.
 .br
 
 Both are released under the \s-1GNU\s0 General Public License,

--- a/man/man1/trash-rm.1
+++ b/man/man1/trash-rm.1
@@ -42,6 +42,6 @@ trash-list(1),
 trash-empty(1),
 trash-restore(1), 
 and the FreeDesktop.org Trash Specification at 
-http://www.ramendik.ru/docs/trashspec.html.
+https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html.
 .br
 


### PR DESCRIPTION
Closes: https://github.com/andreafrancia/trash-cli/issues/231

`grep -lr ramend . | xargs sed -i 's#http://www\.ramendik\.ru/docs/trashspec\.html#https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html#g'`