### PR TITLE
Fix trash-empty not showing nfs4 mountpoints

### DIFF
--- a/trashcli/list_mount_points.py
+++ b/trashcli/list_mount_points.py
@@ -12,6 +12,7 @@ def os_mount_points():
     # List of accepted non-physical fstypes
     fstypes = [
         'nfs',
+        'nfs4',
         'p9', # file system used in WSL 2 (Windows Subsystem for Linux)
     ]
 


### PR DESCRIPTION
Add 'nfs4' fstype to listed mountpoints. Fixes #229 actually.