### PR TITLE
Add 'fuse.mergerfs' to fs whitelist

### DIFF
--- a/trashcli/list_mount_points.py
+++ b/trashcli/list_mount_points.py
@@ -12,6 +12,7 @@ def os_mount_points():
         'btrfs',
         'fuse', # https://github.com/andreafrancia/trash-cli/issues/250
         'fuse.glusterfs', #https://github.com/andreafrancia/trash-cli/issues/255
+        'fuse.mergerfs',
     ]
 
     # Append fstypes of physical devices to list


### PR DESCRIPTION
Similar to #250 and #255. Related to #256.

The following should probably also be added:
- `aufs`
- `fuse.overlayfs`