### PR TITLE
Feat: add installation guide for Arch Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,6 +204,10 @@ Debian/Ubuntu (apt)::
 
     sudo apt install trash-cli
 
+Arch Linux (pacman)::
+
+    sudo pacman -S trash-cli
+
 Install shell completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add pacman command to install on Arch Linux.
https://archlinux.org/packages/community/any/trash-cli/