### PR TITLE
Get back '--' the cmd option ending indicator by reverting "Fix #264"

### DIFF
--- a/trashcli/put/parser.py
+++ b/trashcli/put/parser.py
@@ -105,6 +105,6 @@ Report bugs to https://github.com/andreafrancia/trash-cli/issues""")
                         action="version",
                         version=version)
     parser.add_argument('files',
-                        nargs='...'
+                        nargs='*'
                         ).complete = TRASH_FILES
     return parser


### PR DESCRIPTION
Revert #270.

It's not a perfect fix, breaks the usage of `--` to indicate the end of cmd options.

```shell
❯ command trash-put -- 1.txt
trash-put: cannot trash non existent '--'
```

Besides, seems `nargs` `argparse.REMAINDER/...` is deprecated cause it's not documented anymore.

Related

- https://github.com/andreafrancia/trash-cli/pull/270
- https://github.com/andreafrancia/trash-cli/issues/264
- https://docs.python.org/3.10/library/argparse.html#nargs