### PR TITLE
Check trash-info target trash folder non-exists before confirming

### DIFF
--- a/trashcli/put/info_dir.py
+++ b/trashcli/put/info_dir.py
@@ -4,6 +4,7 @@ import os
 from trashcli.put.fs.fs import Fs
 from trashcli.put.my_logger import MyLogger, LogData
 from trashcli.put.suffix import Suffix
+from trashcli.trash import path_of_backup_copy
 
 
 class InfoDir:
@@ -27,14 +28,18 @@ class InfoDir:
         returns the created TrashInfoFile.
         """
 
-        index = 0
+        index = -1
         name_too_long = False
         while True:
+            index += 1
+
             suffix = self.suffix.suffix_for_index(index)
             trashinfo_basename = create_trashinfo_basename(basename,
                                                            suffix,
                                                            name_too_long)
             trashinfo_path = os.path.join(info_dir_path, trashinfo_basename)
+            if os.path.exists(path_of_backup_copy(trashinfo_path)):
+                continue
             try:
                 self.fs.atomic_write(trashinfo_path, content)
                 self.logger.debug(".trashinfo created as %s." % trashinfo_path,
@@ -47,7 +52,6 @@ class InfoDir:
                     "attempt for creating %s failed." % trashinfo_path,
                     log_data)
 
-            index += 1
 
 
 def create_trashinfo_basename(basename, suffix, name_too_long):


### PR DESCRIPTION
Currently, there's a loop to append suffixes (_1, _2, _3, ...) when trashinfo already exists, which is good.

However, given a trashinfo, our target `path_of_backup_copy` might already exists, which will cause the algorithm to fail.

E.g.:
```sh
$ ls ~/.local/share/Trash/info
my_dir_1.trashinfo

$ ls ~/.local/share/Trash/files
my_dir_1/
my_dir_2/
my_dir_3/
```

The looping will confirm to use `my_dir_2.trashinfo` as the target trashinfo, and only realises that the `my_dir_2 = path_of_backup_copy("my_dir_2.trashinfo")` actually already exists when performing the move via OS call:
```
trash: Failed to trash build/ in ~/.local/share/Trash, because: Destination path '/home/xxx/.local/share/Trash/files/my_dir_2/build' already exists
```

----------

The existence of `my_dir_2/`, `my_dir_3/`, ... might be due to other similar named files, trashed by the system file manager, etc.