### PR TITLE
added --currentdir option to trash-list

### DIFF
--- a/trashcli/list/list_trash_action.py
+++ b/trashcli/list/list_trash_action.py
@@ -125,7 +125,7 @@ class ListTrash:
         else:
             try:
                 relative_location = parse_path(contents)
-                if not cur_work_dir in relative_location and only_print_wd:
+                if not relative_location.startswith(cur_work_dir) and only_print_wd:
                     return
             except ParseError:
                 yield Error(self.print_parse_path_error(trashinfo_path))

--- a/trashcli/list/parser.py
+++ b/trashcli/list/parser.py
@@ -43,6 +43,11 @@ class Parser:
                                  action='store_const',
                                  const=Action.list_volumes,
                                  help="list volumes")
+        self.parser.add_argument('--currentdir',
+                                 action='store_true',
+                                 default=False,
+                                 dest='only_print_wd',
+                                 help="Only show files trashed from current directory")
         self.parser.add_argument('--trash-dirs',
                                  dest='action',
                                  action='store_const',
@@ -98,6 +103,7 @@ class Parser:
                 trash_dirs=parsed.trash_dirs,
                 attribute_to_print=parsed.attribute_to_print,
                 show_files=parsed.show_files,
+                only_print_wd=parsed.only_print_wd,
                 all_users=parsed.all_users
             )
         if parsed.action == Action.print_python_executable:


### PR DESCRIPTION
Added a new command line option to `trash-list`, `--currentdir`. This will only display files which were trashed from the current directory (and all subdirectories similar to trash-restore). 

Based on this open issue: https://github.com/andreafrancia/trash-cli/issues/304