### PR TITLE
improved error messages when no files were restored

### DIFF
--- a/tests/test_empty/test_empty_end_to_end_interactive.py
+++ b/tests/test_empty/test_empty_end_to_end_interactive.py
@@ -39,7 +39,7 @@ class TestEmptyEndToEndInteractive(unittest.TestCase):
         assert result.all == [
             'Would empty the following trash directories:\n'
             '    - %s\n'
-            'Proceed? (y/n) ' % self.trash_dir, '', 0]
+            'Proceed? (y/N) ' % self.trash_dir, '', 0]
 
     def tearDown(self):
         self.tmp_dir.clean_up()

--- a/tests/test_empty/test_prepare_output_message.py
+++ b/tests/test_empty/test_prepare_output_message.py
@@ -14,7 +14,7 @@ class TestPrepareOutputMessage(unittest.TestCase):
         assert """\
 Would empty the following trash directories:
     - /Trash
-Proceed? (y/n) """ == result
+Proceed? (y/N) """ == result
 
     def test_multiple_dirs(self):
         trash_dirs = [
@@ -27,7 +27,7 @@ Proceed? (y/n) """ == result
 Would empty the following trash directories:
     - /Trash1
     - /Trash2
-Proceed? (y/n) """ == result
+Proceed? (y/N) """ == result
 
     def test_no_dirs(self):
         trash_dirs = []

--- a/trashcli/empty/prepare_output_message.py
+++ b/trashcli/empty/prepare_output_message.py
@@ -9,7 +9,7 @@ def prepare_output_message(trash_dirs):
             if event == trash_dir_found:
                 trash_dir, volume = args
                 result.append("    - %s" % trash_dir)
-        result.append("Proceed? (y/n) ")
+        result.append("Proceed? (y/N) ")
         return "\n".join(result)
     else:
         return 'No trash directories to empty.\n'

--- a/trashcli/restore/restore_asking_the_user.py
+++ b/trashcli/restore/restore_asking_the_user.py
@@ -52,7 +52,7 @@ class RestoreAskingTheUser(object):
             return Left(Quit())
         else:
             if user_input == "":
-                return Left(Exiting())
+                return Left(Die("No files were restored"))
             else:
                 return Right(
                     InputRead(user_input, args.trashed_files, args.overwrite))


### PR DESCRIPTION
Fixes #326 
This change makes behavior more transparent when trying to restore a file, but choosing nothing. 
It also capitalizes the letter `N` in trash-empty confirmation, to clarify default behavior.