### PR TITLE
Add fuse.gocryptfs to fstype whitelist

### DIFF
--- a/trashcli/fstab/mount_points_listing.py
+++ b/trashcli/fstab/mount_points_listing.py
@@ -40,6 +40,7 @@ def os_mount_points():
         'fuse.glusterfs',
         # https://github.com/andreafrancia/trash-cli/issues/255
         'fuse.mergerfs',
+        'fuse.gocryptfs',
     ]
 
     # Append fstypes of physical devices to list


### PR DESCRIPTION
Similarly to #255, on a decrypted `gocryptfs` share I could `trash-put` a file (which created .Trash-1000 dir), but I could not list or restore the trashed file without specifying `--trash-dir /path/to/.Trash-1000`).

Adding this type fixed the issue for me, I could both `trash-list` and `trash-restore` the files.

Ref #256