### PR TITLE
Prevent calling `trash-list --trash-dirs` at eval time

### DIFF
--- a/trashcli/shell_completion.py
+++ b/trashcli/shell_completion.py
@@ -62,4 +62,4 @@ except ImportError:
         pass
 
 TRASH_FILES.update({"zsh": "_trash_files"})
-TRASH_DIRS.update({"zsh": "(${$(trash-list --trash-dirs)#parent_*:})"})
+TRASH_DIRS.update({"zsh": "(\\${\\$(trash-list --trash-dirs)#parent_*})"})


### PR DESCRIPTION
The previous behavior caused a significant completion slowdown on linux systems with unresponsive mountpoints, which need to time out before `trash-list --trash-dirs` returns. This is inevitable when completing arguments to `--trash-dir`, but it should not slowdown unrelated completion queries.

Fixes #335, and likely will make completion a little bit faster for everyone. 