### PR TITLE
--currentdir functionality, resubmitted from current master branch

### DIFF
--- a/tests/test_list/cmd/support.py
+++ b/tests/test_list/cmd/support.py
@@ -11,6 +11,7 @@ from trashcli.empty.top_trash_dir_rules_file_system_reader import \
 from trashcli.file_system_reader import FileSystemReader
 from trashcli.fstab.volume_listing import VolumesListing
 from trashcli.lib.dir_reader import RealDirReader
+from trashcli.restore.file_system import FakeReadCwd
 from trashcli.list.main import ListCmd
 
 
@@ -24,6 +25,7 @@ class TrashListUser:
         trash_dir = os.path.join(xdg_data_home, "Trash")
         self.home_trashdir = FakeTrashDir(trash_dir)
         self.version = None
+        self.fake_cwd = FakeReadCwd("dir")
 
     def run_trash_list(self, *args):
         self.run('trash-list', *args)
@@ -44,11 +46,15 @@ class TrashListUser:
             dir_reader=RealDirReader(),
             file_reader=RealTopTrashDirRulesReader(),
             content_reader=FileSystemContentReader(),
-            version=self.version
+            version=self.version,
+            read_cwd=self.fake_cwd
         ).run(argv)
 
     def set_fake_uid(self, uid):
         self.fake_uid = uid
+        
+    def set_fake_cwd(self, cwd_name):
+        self.fake_cwd = FakeReadCwd(cwd_name)
 
     def add_volume(self, mount_point):
         self.volumes.append(mount_point)

--- a/tests/test_list/cmd/test_end_to_end_list.py
+++ b/tests/test_list/cmd/test_end_to_end_list.py
@@ -64,7 +64,7 @@ class TestEndToEndList(unittest.TestCase):
 
         self.assertEqual(reformat_help_message("""\
 usage: trash-list [-h] [--print-completion {bash,zsh,tcsh}] [--version]
-                  [--volumes] [--trash-dirs] [--trash-dir TRASH_DIRS]
+                  [--volumes] [--currentdir] [--trash-dirs] [--trash-dir TRASH_DIRS]
                   [--all-users]
 
 List trashed files
@@ -75,6 +75,7 @@ options:
                         print shell completion script
   --version             show program's version number and exit
   --volumes             list volumes
+  --currentdir          only show files trashed from current directory
   --trash-dirs          list trash dirs
   --trash-dir TRASH_DIRS
                         specify the trash directory to use

--- a/tests/test_list/cmd/test_trash_list.py
+++ b/tests/test_list/cmd/test_trash_list.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
 from datetime import datetime
+import os
 
 from tests.support.sort_lines import sort_lines
 from tests.test_list.cmd.setup import Setup
@@ -22,6 +23,28 @@ class TestTrashList(Setup):
         self.user.run_trash_list()
 
         assert_equals_with_unidiff("2001-02-03 23:55:59 /absolute/path\n",
+                                   self.user.output())
+                                   
+    def test_should_output_only_currentdir_with_currentdir_option(self):
+        self.user.home_trashdir.add_trashinfo2(os.getcwd() + '/absolute/path/file1',
+                                               datetime(2001, 2, 3, 23, 55, 59))
+        self.user.home_trashdir.add_trashinfo2('/absolute/path/file2',
+                                               datetime(2001, 2, 3, 23, 55, 59))
+
+        self.user.run_trash_list('--currentdir')
+
+        assert_equals_with_unidiff("2001-02-03 23:55:59 " + os.getcwd() + "/absolute/path/file1\n",
+                                   self.user.output())
+
+    def test_should_output_currendir_should_not_show_currentdir_itself(self):
+        self.user.home_trashdir.add_trashinfo2(os.getcwd(),
+                                               datetime(2001, 2, 3, 23, 55, 59))
+        self.user.home_trashdir.add_trashinfo2('/absolute/path/file2',
+                                               datetime(2001, 2, 3, 23, 55, 59))
+
+        self.user.run_trash_list('--currentdir')
+
+        assert_equals_with_unidiff("",
                                    self.user.output())
 
     def test_should_output_info_for_multiple_files(self):

--- a/tests/test_list/cmd/test_trash_list.py
+++ b/tests/test_list/cmd/test_trash_list.py
@@ -24,28 +24,6 @@ class TestTrashList(Setup):
 
         assert_equals_with_unidiff("2001-02-03 23:55:59 /absolute/path\n",
                                    self.user.output())
-                                   
-    def test_should_output_only_currentdir_with_currentdir_option(self):
-        self.user.home_trashdir.add_trashinfo2(os.getcwd() + '/absolute/path/file1',
-                                               datetime(2001, 2, 3, 23, 55, 59))
-        self.user.home_trashdir.add_trashinfo2('/absolute/path/file2',
-                                               datetime(2001, 2, 3, 23, 55, 59))
-
-        self.user.run_trash_list('--currentdir')
-
-        assert_equals_with_unidiff("2001-02-03 23:55:59 " + os.getcwd() + "/absolute/path/file1\n",
-                                   self.user.output())
-
-    def test_should_output_currendir_should_not_show_currentdir_itself(self):
-        self.user.home_trashdir.add_trashinfo2(os.getcwd(),
-                                               datetime(2001, 2, 3, 23, 55, 59))
-        self.user.home_trashdir.add_trashinfo2('/absolute/path/file2',
-                                               datetime(2001, 2, 3, 23, 55, 59))
-
-        self.user.run_trash_list('--currentdir')
-
-        assert_equals_with_unidiff("",
-                                   self.user.output())
 
     def test_should_output_info_for_multiple_files(self):
         self.user.home_trashdir.add_trashinfo2("/file1",

--- a/tests/test_list/cmd/test_trash_list.py
+++ b/tests/test_list/cmd/test_trash_list.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
 from datetime import datetime
-import os
 
 from tests.support.sort_lines import sort_lines
 from tests.test_list.cmd.setup import Setup

--- a/tests/test_list/cmd/test_trash_list_current_directory.py
+++ b/tests/test_list/cmd/test_trash_list_current_directory.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
+
+from datetime import datetime
+import os
+
+from tests.support.sort_lines import sort_lines
+from tests.test_list.cmd.setup import Setup
+
+from tests.support.asserts import assert_equals_with_unidiff
+
+
+class TestTrashListCurrentDirectory(Setup):
+    def setUp(self):
+        super(type(self), self).setUp()
+        self.user.set_fake_cwd("/home/user/currentdir")
+                                   
+    def test_currentdir_files_only(self):
+        self.user.home_trashdir.add_trashinfo2('/home/user/currentdir/file1',
+                                               datetime(2001, 2, 3, 23, 55, 59))
+        self.user.home_trashdir.add_trashinfo2('/home/user/otherdir/file2',
+                                               datetime(2001, 2, 3, 23, 55, 59))
+
+        self.user.run_trash_list('--currentdir')
+
+        assert_equals_with_unidiff("2001-02-03 23:55:59 " + "/home/user/currentdir/file1\n",
+                                   self.user.output())
+
+    def test_currentdir_nested_folders(self):
+        self.user.home_trashdir.add_trashinfo2('/home/user/otherdir/currentdir/file1',
+                                               datetime(2001, 2, 3, 23, 55, 59))
+        self.user.home_trashdir.add_trashinfo2('/home/user/currentdir/newdirectory/file2',
+                                               datetime(2001, 2, 3, 23, 55, 59))
+
+        self.user.run_trash_list('--currentdir')
+
+        assert_equals_with_unidiff("2001-02-03 23:55:59 " + "/home/user/currentdir/newdirectory/file2\n",
+                                   self.user.output())
+
+
+    def test_should_output_currendir_should_not_show_currentdir_itself(self):
+        self.user.home_trashdir.add_trashinfo2("/home/user/currentdir",
+                                               datetime(2001, 2, 3, 23, 55, 59))
+        self.user.home_trashdir.add_trashinfo2('/home/user/otherdir/file1',
+                                               datetime(2001, 2, 3, 23, 55, 59))
+
+        self.user.run_trash_list('--currentdir')
+
+        assert_equals_with_unidiff("",
+                                   self.user.output())

--- a/tests/test_list/cmd/test_trash_list_current_directory.py
+++ b/tests/test_list/cmd/test_trash_list_current_directory.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
 
 from datetime import datetime
-import os
 
 from tests.support.sort_lines import sort_lines
 from tests.test_list.cmd.setup import Setup

--- a/trashcli/list/list_trash_action.py
+++ b/trashcli/list/list_trash_action.py
@@ -23,6 +23,7 @@ class ListTrashArgs(
         ('trash_dirs', List[str]),
         ('attribute_to_print', str),
         ('show_files', bool),
+        ('only_print_wd', bool),
         ('all_users', bool),
     ])):
     pass
@@ -87,6 +88,7 @@ class ListTrash:
         user_specified_trash_dirs = args.trash_dirs
         extractor = extractors[args.attribute_to_print]
         show_files = args.show_files
+        only_print_wd = args.only_print_wd
         all_users = args.all_users
         trash_dirs = self.selector.select(all_users,
                                           user_specified_trash_dirs,
@@ -96,9 +98,10 @@ class ListTrash:
             if event == trash_dir_found:
                 path, volume = event_args
                 trash_dir = TrashDirReader(self.dir_reader)
+                cur_work_dir = os.getcwd()
                 for trash_info in trash_dir.list_trashinfo(path):
                     for msg in self._print_trashinfo(volume, trash_info,
-                                                     extractor, show_files):
+                                                     extractor, show_files, only_print_wd, cur_work_dir):
                         yield msg
             elif event == trash_dir_skipped_because_parent_not_sticky:
                 path, = event_args
@@ -115,7 +118,9 @@ class ListTrash:
                          volume,
                          trashinfo_path,
                          extractor,
-                         show_files):
+                         show_files,
+                         only_print_wd,
+                         cur_work_dir):
         try:
             contents = self.content_reader.contents_of(trashinfo_path)
         except IOError as e:
@@ -123,6 +128,8 @@ class ListTrash:
         else:
             try:
                 relative_location = parse_path(contents)
+                if only_print_wd and not relative_location.startswith(cur_work_dir + "/"):
+                	return
             except ParseError:
                 yield Error(self.print_parse_path_error(trashinfo_path))
             else:

--- a/trashcli/list/main.py
+++ b/trashcli/list/main.py
@@ -24,6 +24,7 @@ from trashcli.list.minor_actions.print_python_executable import \
 from trashcli.list.parser import Parser
 from trashcli.list.trash_dir_selector import TrashDirsSelector
 from trashcli.trash_dirs_scanner import TopTrashDirRules
+from trashcli.restore.file_system import RealReadCwd
 
 
 def main():
@@ -37,7 +38,8 @@ def main():
         dir_reader=RealDirReader(),
         file_reader=FileSystemReader(),
         content_reader=RealContentsOf(),
-        version=trashcli.trash.version
+        version=trashcli.trash.version,
+        read_cwd=RealReadCwd()
     ).run(sys.argv)
 
 
@@ -53,6 +55,7 @@ class ListCmd:
                  dir_reader,  # type: DirReader
                  content_reader, # type: ContentReader
                  version,
+                 read_cwd,
                  ):
         self.out = out
         self.err = err
@@ -61,6 +64,7 @@ class ListCmd:
         self.content_reader = content_reader
         self.environ = environ
         self.uid = uid
+        self.read_cwd = read_cwd
         self.volumes_listing = volumes_listing
         self.selector = TrashDirsSelector.make(volumes_listing,
                                                file_reader,
@@ -80,7 +84,8 @@ class ListCmd:
                                                        self.out,
                                                        self.err,
                                                        self.dir_reader,
-                                                       self.content_reader),
+                                                       self.content_reader,
+                                                       self.read_cwd.getcwd_as_realpath()),
                         PrintPythonExecutableArgs: PrintPythonExecutable()}
 
     def run(self, argv):

--- a/trashcli/list/parser.py
+++ b/trashcli/list/parser.py
@@ -43,6 +43,11 @@ class Parser:
                                  action='store_const',
                                  const=ListAction.list_volumes,
                                  help="list volumes")
+        self.parser.add_argument('--currentdir',
+                                 dest='only_print_wd',
+                                 action='store_true',
+                                 default=False,
+                                 help="only show files trashed from current directory")
         self.parser.add_argument('--trash-dirs',
                                  dest='action',
                                  action='store_const',
@@ -98,6 +103,7 @@ class Parser:
                 trash_dirs=parsed.trash_dirs,
                 attribute_to_print=parsed.attribute_to_print,
                 show_files=parsed.show_files,
+                only_print_wd=parsed.only_print_wd,
                 all_users=parsed.all_users
             )
         if parsed.action == ListAction.print_python_executable:


### PR DESCRIPTION
Resubmitted https://github.com/andreafrancia/trash-cli/pull/306 from new master branch as there were issues with old pull request. 

Based on issue https://github.com/andreafrancia/trash-cli/issues/304

(Also a minor change from last time, it now won't print the current directory if there was a previous directory with the same name that was trashed)