### PR TITLE
Bugfix in print-completion loop for shells other than zsh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,7 +235,7 @@ or::
 Then::
 
     cmds=(trash-empty trash-list trash-restore trash-put trash)
-    for cmd in $cmds; do
+    for cmd in ${cmds[@]}; do
       $cmd --print-completion bash | sudo tee /usr/share/bash-completion/completions/$cmd
       $cmd --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_$cmd
       $cmd --print-completion tcsh | sudo tee /etc/profile.d/$cmd.completion.csh


### PR DESCRIPTION
Bash and other sh type shells only execute the loop for the first element of the `cmds` array using the old code