### PR TITLE
Relax version requirement on virtualenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-requires = virtualenv<20.22.0
+requires = virtualenv<21.0.0
 envlist = py27, py310
 
 [testenv]


### PR DESCRIPTION
I just used the next major version a new upper bound, let me know if  you want me to change that to a more specific version or something else.

Closes: #360 