### PR TITLE
Do not ask which file to restore if there is only one option

### DIFF
--- a/tests/test_restore/cmd/test_end_to_end_restore.py
+++ b/tests/test_restore/cmd/test_end_to_end_restore.py
@@ -31,10 +31,9 @@ No files trashed from current dir ('%s')
     def test_original_file_not_existing(self):
         self.fake_trash_dir.add_trashinfo3("foo", "/path", datetime(2000,1,1,0,0,1))
 
-        result = self.run_command("trash-restore", ["/"], input='0')
+        result = self.run_command("trash-restore", ["/"])
 
-        self.assertEqual("   0 2000-01-01 00:00:01 /path\n" 
-                         "What file to restore [0..0]: \n"
+        self.assertEqual("2000-01-01 00:00:01 /path\n"
                          "[Errno 2] No such file or directory: '%s/files/foo'\n" %
                          self.trash_dir,
                          result.output())
@@ -67,11 +66,11 @@ What file to restore [0..1]: """ % { 'curdir': self.curdir},
 
         result = self.run_command("trash-restore",
                                   ["%(curdir)s" % {'curdir': "."},
-                                   '--sort=path'], input='0')
+                                   '--sort=path'])
 
         self.assertEqual("""\
-   0 2000-01-01 00:00:01 %(curdir)s/path/to/file1
-What file to restore [0..0]: """ % {'curdir': self.curdir},
+2000-01-01 00:00:01 %(curdir)s/path/to/file1
+""" % {'curdir': self.curdir},
                          result.stdout)
         self.assertEqual("", result.stderr)
         self.assertEqual("contents", read_file(pj(self.curdir, "path/to/file1")))

--- a/tests/test_restore/cmd/test_listing_in_restore_cmd.py
+++ b/tests/test_restore/cmd/test_listing_in_restore_cmd.py
@@ -70,6 +70,6 @@ class FakeHandler(Handler):
     def __init__(self, original_locations):
         self.original_locations = original_locations
 
-    def handle_trashed_files(self, trashed_files, _overwrite):
+    def handle_trashed_files(self, trashed_files, _overwrite, _no_ask):
         for trashed_file in trashed_files:
             self.original_locations.append(trashed_file.original_location)

--- a/tests/test_restore/components/arg_parser/test_restore_arg_parser.py
+++ b/tests/test_restore/components/arg_parser/test_restore_arg_parser.py
@@ -13,6 +13,7 @@ class TestRestoreArgs(unittest.TestCase):
         args = self.parser.parse_restore_args([''], "curdir")
 
         self.assertEqual(RunRestoreArgs(path='curdir',
+                                        path_passed=False,
                                         sort=Sort.ByDate,
                                         trash_dir=None,
                                         overwrite=False),
@@ -22,6 +23,7 @@ class TestRestoreArgs(unittest.TestCase):
         args = self.parser.parse_restore_args(['', 'path'], "curdir")
 
         self.assertEqual(RunRestoreArgs(path='curdir/path',
+                                        path_passed=True,
                                         sort=Sort.ByDate,
                                         trash_dir=None,
                                         overwrite=False),
@@ -31,6 +33,7 @@ class TestRestoreArgs(unittest.TestCase):
         args = self.parser.parse_restore_args(['', '/a/path'], "ignored")
 
         self.assertEqual(RunRestoreArgs(path='/a/path',
+                                        path_passed=True,
                                         sort=Sort.ByDate,
                                         trash_dir=None,
                                         overwrite=False),

--- a/tests/test_restore/components/collaborators/test_restore_asking_the_user.py
+++ b/tests/test_restore/components/collaborators/test_restore_asking_the_user.py
@@ -22,7 +22,7 @@ class TestRestoreAskingTheUser(unittest.TestCase):
         self.input.set_reply('0')
 
         self.asking_user.restore_asking_the_user(['trashed_file1',
-                                                  'trashed_file2'], False)
+                                                  'trashed_file2'], False, False)
 
         self.assertEqual('What file to restore [0..1]: ',
                          self.input.last_prompt())
@@ -34,7 +34,7 @@ class TestRestoreAskingTheUser(unittest.TestCase):
         self.input.raise_exception(KeyboardInterrupt)
 
         self.asking_user.restore_asking_the_user(['trashed_file1',
-                                                  'trashed_file2'], False)
+                                                  'trashed_file2'], False, False)
 
         self.assertEqual('What file to restore [0..1]: ',
                          self.input.last_prompt())

--- a/trashcli/restore/args.py
+++ b/trashcli/restore/args.py
@@ -16,6 +16,7 @@ class Sort(Enum):
 class RunRestoreArgs(
     NamedTuple('RunRestoreArgs', [
         ('path', str),
+        ('path_passed', bool),
         ('sort', Sort),
         ('trash_dir', Optional[str]),
         ('overwrite', bool),

--- a/trashcli/restore/handler.py
+++ b/trashcli/restore/handler.py
@@ -28,23 +28,31 @@ class HandlerImpl(Handler):
     def handle_trashed_files(self,
                              trashed_files,  # type: List[TrashedFile]
                              overwrite,  # type: bool
+                             single_no_ask,  # type: bool
                              ):
         if not trashed_files:
             self.report_no_files_found(self.cwd.getcwd_as_realpath())
         else:
-            for i, trashed_file in enumerate(trashed_files):
-                self.output.println("%4d %s %s" % (i,
-                                                   trashed_file.deletion_date,
-                                                   trashed_file.original_location))
-            self.restore_asking_the_user(trashed_files, overwrite)
+            if single_no_ask and len(trashed_files) == 1:
+                trashed_file = trashed_files[0]
+                self.output.println("%s %s" % (trashed_file.deletion_date,
+                                               trashed_file.original_location))
+                self.restore_asking_the_user(trashed_files, overwrite, no_ask=True)
+            else:
+                for i, trashed_file in enumerate(trashed_files):
+                    self.output.println("%4d %s %s" % (i,
+                                                       trashed_file.deletion_date,
+                                                       trashed_file.original_location))
+                self.restore_asking_the_user(trashed_files, overwrite)
 
-    def restore_asking_the_user(self, trashed_files, overwrite=False):
+    def restore_asking_the_user(self, trashed_files, overwrite=False, no_ask=False):
         my_output = OutputRecorder()
         restore_asking_the_user = RestoreAskingTheUser(self.input,
                                                        self.restorer,
                                                        my_output)
         restore_asking_the_user.restore_asking_the_user(trashed_files,
-                                                        overwrite)
+                                                        overwrite,
+                                                        no_ask)
         my_output.apply_to(self.output)
 
     def report_no_files_found(self, directory):  # type: (str) -> None

--- a/trashcli/restore/restore_arg_parser.py
+++ b/trashcli/restore/restore_arg_parser.py
@@ -51,10 +51,12 @@ class RestoreArgParser:
         if parsed.version:
             return PrintVersionArgs(argv0=sys_argv[0])
         else:
+            path_passed = parsed.path != ""
             path = os.path.normpath(
                 os.path.join(curdir + os.path.sep, parsed.path))
 
             return RunRestoreArgs(path=path,
+                                  path_passed=path_passed,
                                   sort=cast(Sort, {
                                       'path': Sort.ByPath,
                                       'date': Sort.ByDate,

--- a/trashcli/restore/restore_asking_the_user.py
+++ b/trashcli/restore/restore_asking_the_user.py
@@ -58,9 +58,12 @@ class RestoreAskingTheUser(object):
                 return Right(
                     InputRead(user_input, args.trashed_files, args.overwrite))
 
-    def restore_asking_the_user(self, trashed_files, overwrite):
+    def restore_asking_the_user(self, trashed_files, overwrite, no_ask):
         input = Right(Context(trashed_files, overwrite))
         compose(input, [
+            select_all,
+            self.restore_selected_files,
+        ] if no_ask else [
             self.read_user_input,
             trashed_files_to_restore,
             self.restore_selected_files,
@@ -136,6 +139,12 @@ def trashed_files_to_restore(input_read,  # type: InputRead
         return Right(selected_files)
     except InvalidEntry as e:
         return Left(Die("Invalid entry: %s" % e))
+
+
+def select_all(input_read,  # type: InputRead
+               ):  # type: (...) -> Either[Die, SelectedFiles]
+    selected_files = SelectedFiles(input_read.trashed_files, input_read.overwrite)
+    return Right(selected_files)
 
 
 class InvalidEntry(Exception):

--- a/trashcli/restore/run_restore_action.py
+++ b/trashcli/restore/run_restore_action.py
@@ -26,7 +26,8 @@ class RunRestoreAction:
         trashed_files = sort_files(args.sort, trashed_files)
 
         self.handler.handle_trashed_files(trashed_files,
-                                          args.overwrite)
+                                          args.overwrite,
+                                          args.path_passed)
 
     def all_files_trashed_from_path(self,
                                     path,  # type: str
@@ -44,6 +45,7 @@ class Handler:
     def handle_trashed_files(self,
                              trashed_files,
                              overwrite,  # type: bool
+                             single_no_ask,  # type: bool
                              ):
         raise NotImplementedError()
 


### PR DESCRIPTION
Ref #175, #359

When a path is passed, and only a single option is available, automatically select that option without waiting for user input. The information usually printed during the selection screen is still printed.

Rationale: the only reason to have a selection when there is only one option, would be to have the option to cancel, but when I explicitly supply a filename, why would I want to? I know what I'm restoring (since I'm passing the filename).
When I *don't* supply a filename, it would IMO not be a good idea to skip this step; since 1. the user doesn't know what file they are restoring and 2. it could just be to list the files able to be restored.

`restore_asking_the_user` and `RestoreAskingTheUser` having a path specifically *not* asking the user is a bit weird, and could be improved; but I wasn't sure how, I would appreciate some help there.

`mypy .` passes
`pytest` passes