### PR TITLE
Replace parameterized with built-in pytest functionality

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@
 pytest
 mock; python_version < '3.3'
 flexmock
-parameterized
 tox
 PyYAML <= 5.4.1; python_version ~= '2.7'
 PyYAML <= 5.2; python_version ~= '3.4'

--- a/tests/test_put/components/test_original_location.py
+++ b/tests/test_put/components/test_original_location.py
@@ -1,7 +1,6 @@
 import os
-import unittest
 
-from parameterized import parameterized  # type: ignore
+import pytest
 
 from tests.support.put.fake_fs.fake_fs import FakeFs
 from trashcli.put.core.path_maker_type import PathMakerType
@@ -11,29 +10,34 @@ AbsolutePaths = PathMakerType.AbsolutePaths
 RelativePaths = PathMakerType.RelativePaths
 
 
-class TestOriginalLocation(unittest.TestCase):
+@pytest.fixture()
+def original_location():
+    yield OriginalLocation(FakeFsWithRealpath())
 
-    def setUp(self):
-        self.original_location = OriginalLocation(FakeFsWithRealpath())
 
-    @parameterized.expand([
-        ('/volume', '/file', AbsolutePaths, '/file',),
-        ('/volume', '/file/././', AbsolutePaths, '/file',),
-        ('/volume', '/dir/../file', AbsolutePaths, '/file'),
-        ('/volume', '/dir/../././file', AbsolutePaths, '/file'),
-        ('/volume', '/outside/file', AbsolutePaths, '/outside/file'),
-        ('/volume', '/volume/file', AbsolutePaths, '/volume/file',),
-        ('/volume', '/volume/dir/file', AbsolutePaths, '/volume/dir/file'),
-        ('/volume', '/file', RelativePaths, '/file'),
-        ('/volume', '/dir/../file', RelativePaths, '/file'),
-        ('/volume', '/outside/file', RelativePaths, '/outside/file'),
-        ('/volume', '/volume/file', RelativePaths, 'file'),
-        ('/volume', '/volume/dir/file', RelativePaths, 'dir/file'),
-    ])
+class TestOriginalLocation:
+
+    @pytest.mark.parametrize(
+        "volume,file_to_be_trashed,path_type,expected_result",
+        [
+            ('/volume', '/file', AbsolutePaths, '/file',),
+            ('/volume', '/file/././', AbsolutePaths, '/file',),
+            ('/volume', '/dir/../file', AbsolutePaths, '/file'),
+            ('/volume', '/dir/../././file', AbsolutePaths, '/file'),
+            ('/volume', '/outside/file', AbsolutePaths, '/outside/file'),
+            ('/volume', '/volume/file', AbsolutePaths, '/volume/file',),
+            ('/volume', '/volume/dir/file', AbsolutePaths, '/volume/dir/file'),
+            ('/volume', '/file', RelativePaths, '/file'),
+            ('/volume', '/dir/../file', RelativePaths, '/file'),
+            ('/volume', '/outside/file', RelativePaths, '/outside/file'),
+            ('/volume', '/volume/file', RelativePaths, 'file'),
+            ('/volume', '/volume/dir/file', RelativePaths, 'dir/file'),
+        ]
+    )
     def test_original_location(self, volume, file_to_be_trashed, path_type,
-                               expected_result):
-        result = self.original_location.for_file(file_to_be_trashed, path_type,
-                                                 volume)
+                               expected_result, original_location):
+        result = original_location.for_file(file_to_be_trashed, path_type,
+                                            volume)
         assert expected_result == result
 
 

--- a/tests/test_support/test_help_reformatting/test_split_paragraphs.py
+++ b/tests/test_support/test_help_reformatting/test_split_paragraphs.py
@@ -1,9 +1,9 @@
-from parameterized import parameterized  # type: ignore
+import pytest
 
 from tests.support.help.help_reformatting import split_paragraphs
 
 
-@parameterized.expand([
+@pytest.mark.parametrize("text,expected_result", [
     ('one line', ['one line']),
     ('one line\n', ['one line\n']),
     ('one\ntwo\n', ['one\ntwo\n']),

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps =
     pytest
     mock; python_version < '3.3'
     flexmock
-    parameterized
     # build testing
     setuptools
 commands =


### PR DESCRIPTION
The [`parameterized`](https://pypi.org/project/parameterized/) package doesn’t seem to be actively maintained; see https://github.com/wolever/parameterized/issues/181. It has various compatibility issues with recent Python and pytest releases. This PR replaces it with built-in pytest functionality documented at https://docs.pytest.org/en/stable/how-to/parametrize.html.