### PR TITLE
better display of missing trashinfo

### DIFF
--- a/tests/test_restore/components/arg_parser/test_restore_arg_parser.py
+++ b/tests/test_restore/components/arg_parser/test_restore_arg_parser.py
@@ -15,7 +15,8 @@ class TestRestoreArgs(unittest.TestCase):
         self.assertEqual(RunRestoreArgs(path='curdir',
                                         sort=Sort.ByDate,
                                         trash_dir=None,
-                                        overwrite=False),
+                                        overwrite=False,
+                                        show_non_trashinfo=False),
                          args)
 
     def test_path_specified_relative_path(self):
@@ -24,7 +25,8 @@ class TestRestoreArgs(unittest.TestCase):
         self.assertEqual(RunRestoreArgs(path='curdir/path',
                                         sort=Sort.ByDate,
                                         trash_dir=None,
-                                        overwrite=False),
+                                        overwrite=False,
+                                        show_non_trashinfo=False),
                          args)
 
     def test_path_specified_fullpath(self):
@@ -33,7 +35,8 @@ class TestRestoreArgs(unittest.TestCase):
         self.assertEqual(RunRestoreArgs(path='/a/path',
                                         sort=Sort.ByDate,
                                         trash_dir=None,
-                                        overwrite=False),
+                                        overwrite=False,
+                                        show_non_trashinfo=False),
                          args)
 
     def test_show_version(self):

--- a/tests/test_restore/components/trashed_files/test_trashed_files.py
+++ b/tests/test_restore/components/trashed_files/test_trashed_files.py
@@ -60,7 +60,7 @@ class TestTrashedFiles(unittest.TestCase):
                    'trashed_files': trashed_files,
                    'out': self.out.getvalue()} == {
                    'trashed_files': [],
-                   'out': 'WARN: Non .trashinfo file in info dir\n'
+                   'out': 'WARN: Found a total of 1 non .trashinfo files in trash-dirs. Use `trash-list --find-non-trashinfo` to list them.\n'
                }
 
     def test_on_non_parsable_trashinfo(self):

--- a/tests/test_restore/components/trashed_files/test_trashed_files.py
+++ b/tests/test_restore/components/trashed_files/test_trashed_files.py
@@ -60,8 +60,9 @@ class TestTrashedFiles(unittest.TestCase):
                    'trashed_files': trashed_files,
                    'out': self.out.getvalue()} == {
                    'trashed_files': [],
-                   'out': 'WARN: Found a total of 1 non .trashinfo files in trash-dirs. Use `trash-list --find-non-trashinfo` to list them.\n'
+                   'out': 'WARN: Found a total of 1 non .trashinfo files in trash-dirs. Use `trash-restore --show-non-trashinfo` to list them.\n'
                }
+    
 
     def test_on_non_parsable_trashinfo(self):
         self.fs.write_file('/trash-dir/info/info_path.trashinfo',

--- a/trashcli/restore/args.py
+++ b/trashcli/restore/args.py
@@ -19,5 +19,6 @@ class RunRestoreArgs(
         ('sort', Sort),
         ('trash_dir', Optional[str]),
         ('overwrite', bool),
+        ('show_non_trashinfo', bool),
     ])):
     pass

--- a/trashcli/restore/restore_arg_parser.py
+++ b/trashcli/restore/restore_arg_parser.py
@@ -46,6 +46,11 @@ class RestoreArgParser:
                             default=False,
                             help='Overwrite existing files with files coming out of the trash')
 
+        parser.add_argument('--show-non-trashinfo',
+                            action='store_true',
+                            default=False,
+                            help='Show additional info')
+
         parsed = parser.parse_args(sys_argv[1:])
 
         if parsed.version:
@@ -61,4 +66,5 @@ class RestoreArgParser:
                                       'none': Sort.DoNot
                                   }[parsed.sort]),
                                   trash_dir=parsed.trash_dir,
-                                  overwrite=parsed.overwrite)
+                                  overwrite=parsed.overwrite,
+                                  show_non_trashinfo=parsed.show_non_trashinfo)

--- a/trashcli/restore/trashed_files.py
+++ b/trashcli/restore/trashed_files.py
@@ -26,9 +26,12 @@ class TrashedFiles:
     def all_trashed_files(self,
                           trash_dir_from_cli,  # type: Optional[str]
                           ):  # type: (...) -> Iterable[TrashedFile]
+
+        non_trash = 0
         for event in self.all_trashed_files_internal(trash_dir_from_cli):
             if type(event) is NonTrashinfoFileFound:
-                self.logger.warning("Non .trashinfo file in info dir")
+                # self.logger.warning("Non .trashinfo file in info dir")
+                non_trash+=1
             elif type(event) is NonParsableTrashInfo:
                 self.logger.warning(
                     "Non parsable trashinfo file: %s, because %s" %
@@ -39,6 +42,12 @@ class TrashedFiles:
                 yield event.trashed_file
             else:
                 raise RuntimeError()
+
+            if non_trash:
+                self.logger.warning(
+                        "Found a total of %s non .trashinfo files in trash-dirs. Use `trash-list --find-non-trashinfo` to list them." %
+                        (non_trash))
+            
 
     def all_trashed_files_internal(self,
                                    trash_dir_from_cli,  # type: Optional[str]

--- a/trashcli/restore/trashed_files.py
+++ b/trashcli/restore/trashed_files.py
@@ -18,10 +18,12 @@ class TrashedFiles:
                  logger,  # type: RestoreLogger
                  file_reader,  # type: FileReader
                  searcher,  # type: InfoDirSearcher
+                 show_non_trashinfo = False, # type: bool
                  ):
         self.logger = logger
         self.file_reader = file_reader
         self.searcher = searcher
+        self.show_non_trashinfo=show_non_trashinfo
 
     def all_trashed_files(self,
                           trash_dir_from_cli,  # type: Optional[str]
@@ -30,8 +32,10 @@ class TrashedFiles:
         non_trash = 0
         for event in self.all_trashed_files_internal(trash_dir_from_cli):
             if type(event) is NonTrashinfoFileFound:
-                # self.logger.warning("Non .trashinfo file in info dir")
-                non_trash+=1
+                if self.show_non_trashinfo:
+                    self.logger.warning("Non .trashinfo file in info dir '%s'",event.path)
+                else:
+                    non_trash+=1
             elif type(event) is NonParsableTrashInfo:
                 self.logger.warning(
                     "Non parsable trashinfo file: %s, because %s" %
@@ -43,9 +47,9 @@ class TrashedFiles:
             else:
                 raise RuntimeError()
 
-            if non_trash:
+            if non_trash and not self.show_non_trashinfo:
                 self.logger.warning(
-                        "Found a total of %s non .trashinfo files in trash-dirs. Use `trash-list --find-non-trashinfo` to list them." %
+                        "Found a total of %s non .trashinfo files in trash-dirs. Use `trash-restore --show-non-trashinfo` to list them." %
                         (non_trash))
             
 


### PR DESCRIPTION
this is an attempt to fix https://github.com/andreafrancia/trash-cli/issues/352
I added another flag to restore because it seems to be the best way to make sure only the relevant files are shown without duplicating the logic in restore.

it is probably a good idea to have that flag be the same as verbose. or maybe move the logic in restore to some common area so that list and restore can share this code. and then we have this logic go into list