### PR TITLE
Preserve raw filename bytes in trashinfo Path entries

### DIFF
--- a/tests/test_put/cmd/e2e/test_on_non_utf8_filename.py
+++ b/tests/test_put/cmd/e2e/test_on_non_utf8_filename.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+import pytest
+from six import binary_type
+
+from tests.support.dirs.temp_dir import temp_dir
+from tests.test_put.cmd.e2e.run_trash_put import run_trash_put2
+from trashcli.lib.exit_codes import EX_OK
+
+temp_dir = temp_dir
+
+NON_UTF8_BASENAME = b'\xa4-\xc8\xcf-\xc1+\xb8.txt'
+QUOTED_BASENAME = b'%A4-%C8%CF-%C1%2B%B8.txt'
+
+
+@pytest.mark.slow
+def test_trash_put_preserves_non_utf8_filename_bytes(temp_dir):
+    env = {'XDG_DATA_HOME': temp_dir / 'XDG_DATA_HOME',
+           'HOME': temp_dir / 'home'}
+    source_dir = _fsencode(temp_dir / 'source')
+    if not os.path.isdir(source_dir):
+        os.makedirs(source_dir)
+    source_path = os.path.join(source_dir, NON_UTF8_BASENAME)
+    _touch_bytes_path(source_path)
+
+    result = run_trash_put2(temp_dir, [_fsdecode(source_path)], env)
+
+    assert result.exit_code == EX_OK
+    assert not os.path.exists(source_path)
+    files_dir = _fsencode(temp_dir / 'XDG_DATA_HOME' / 'Trash' / 'files')
+    assert os.listdir(files_dir) == [NON_UTF8_BASENAME]
+    info_dir = _fsencode(temp_dir / 'XDG_DATA_HOME' / 'Trash' / 'info')
+    info_entries = os.listdir(info_dir)
+    assert info_entries == [NON_UTF8_BASENAME + b'.trashinfo']
+    with open(os.path.join(info_dir, info_entries[0]), 'rb') as trashinfo:
+        trashinfo_content = trashinfo.read()
+    assert QUOTED_BASENAME in trashinfo_content
+
+
+def _touch_bytes_path(path):
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(fd)
+
+
+def _fsencode(path):
+    if hasattr(os, 'fsencode'):
+        return os.fsencode(path)
+    if isinstance(path, binary_type):
+        return path
+    return path.encode(sys.getfilesystemencoding() or sys.getdefaultencoding())
+
+
+def _fsdecode(path):
+    if hasattr(os, 'fsdecode'):
+        return os.fsdecode(path)
+    return path

--- a/tests/test_trashcli_lib/test_parsing_trashinfo_contents.py
+++ b/tests/test_trashcli_lib/test_parsing_trashinfo_contents.py
@@ -1,7 +1,10 @@
 # Copyright (C) 2011 Andrea Francia Trivolzio(PV) Italy
+import os
+import sys
 import unittest
 from datetime import datetime
 
+from six import binary_type
 from tests.support.py2mock import MagicMock
 
 from trashcli.parse_trashinfo.parse_path import parse_path
@@ -12,6 +15,7 @@ from trashcli.parse_trashinfo.parse_original_location import \
     parse_original_location
 from trashcli.parse_trashinfo.parser_error import ParseError
 from trashcli.parse_trashinfo.parse_deletion_date import parse_deletion_date
+from trashcli.put.format_trash_info import format_original_location
 
 
 class TestParseTrashInfo(unittest.TestCase):
@@ -34,6 +38,16 @@ class TestParseTrashInfo(unittest.TestCase):
                                'DeletionDate=1970-01-01T00:00:00\n')
 
         out.assert_called_with('foo')
+
+    def test_it_should_parse_percent_encoded_non_utf8_path_bytes(self):
+        out = []
+        parser = ParseTrashInfo(on_path=out.append)
+
+        parser.parse_trashinfo('[Trash Info]\n'
+                               'Path=/tmp/%A4-%C8%CF-%C1%2B%B8.txt\n'
+                               'DeletionDate=1970-01-01T00:00:00\n')
+
+        assert _fsencode(out[0]) == b'/tmp/\xa4-\xc8\xcf-\xc1+\xb8.txt'
 
 
 class TestParseDeletionDate(unittest.TestCase):
@@ -81,6 +95,24 @@ def test_how_to_parse_original_path():
         'Path=%2Fpath%2Fto%2Fbe%2Fescaped')
 
 
+def test_parse_path_preserves_non_utf8_path_bytes():
+    path = parse_path('Path=/tmp/%A4-%C8%CF-%C1%2B%B8.txt')
+
+    assert _fsencode(path) == b'/tmp/\xa4-\xc8\xcf-\xc1+\xb8.txt'
+
+
+def test_format_original_location_preserves_non_utf8_path_bytes():
+    raw_path = b'/tmp/\xa4-\xc8\xcf-\xc1+\xb8.txt'
+
+    assert format_original_location(_fsdecode(raw_path)) == \
+           '/tmp/%A4-%C8%CF-%C1%2B%B8.txt'
+
+
+def test_format_original_location_quotes_special_path_characters():
+    assert format_original_location('/tmp/a b+c%/name') == \
+           '/tmp/a%20b%2Bc%25/name'
+
+
 class TestTrashInfoParser(unittest.TestCase):
     def test_1(self):
         assert '/foo.txt' == parse_original_location("[Trash Info]\n"
@@ -105,3 +137,17 @@ def make_trashinfo(date):
 
 def an_empty_trashinfo():
     return ''
+
+
+def _fsencode(path):
+    if hasattr(os, 'fsencode'):
+        return os.fsencode(path)
+    if isinstance(path, binary_type):
+        return path
+    return path.encode(sys.getfilesystemencoding() or sys.getdefaultencoding())
+
+
+def _fsdecode(path):
+    if hasattr(os, 'fsdecode'):
+        return os.fsdecode(path)
+    return path

--- a/trashcli/parse_trashinfo/parse_path.py
+++ b/trashcli/parse_trashinfo/parse_path.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
-from six.moves.urllib.parse import unquote
-
 from trashcli.parse_trashinfo.parser_error import ParseError
+from trashcli.trashinfo_path import unquote_trashinfo_path
 
 
 def parse_path(contents):
     for line in contents.split('\n'):
         if line.startswith('Path='):
-            return unquote(line[len('Path='):])
+            return unquote_trashinfo_path(line[len('Path='):])
     raise ParseError('Unable to parse Path')

--- a/trashcli/parse_trashinfo/parse_trashinfo.py
+++ b/trashcli/parse_trashinfo/parse_trashinfo.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
 import datetime
-from six.moves.urllib.parse import unquote
+
+from trashcli.trashinfo_path import unquote_trashinfo_path
 
 
 def do_nothing(*argv, **argvk): pass
@@ -30,5 +31,5 @@ class ParseTrashInfo:
                     self.found_deletion_date(date)
 
             if line.startswith('Path='):
-                path = unquote(line[len('Path='):])
+                path = unquote_trashinfo_path(line[len('Path='):])
                 self.found_path(path)

--- a/trashcli/put/format_trash_info.py
+++ b/trashcli/put/format_trash_info.py
@@ -1,6 +1,6 @@
 import datetime
 
-from six.moves.urllib.parse import quote as url_quote
+from trashcli.trashinfo_path import quote_trashinfo_path
 
 
 def format_trashinfo(original_location,  # type: str
@@ -17,4 +17,4 @@ def format_date(deletion_date):  # type: (datetime.datetime) -> str
 
 
 def format_original_location(original_location):  # type: (str) -> str
-    return url_quote(original_location, '/')
+    return quote_trashinfo_path(original_location)

--- a/trashcli/trashinfo_path.py
+++ b/trashcli/trashinfo_path.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+
+import os
+import sys
+
+from six import binary_type
+from six import text_type
+
+try:
+    from urllib.parse import quote_from_bytes
+    from urllib.parse import unquote_to_bytes
+except ImportError:
+    from urllib import quote as _quote
+    from urllib import unquote as _unquote
+
+    def quote_from_bytes(raw_path, safe='/'):
+        return _quote(raw_path, safe)
+
+    def unquote_to_bytes(quoted_path):
+        return _unquote(_fsencode(quoted_path))
+
+
+def quote_trashinfo_path(path):
+    return quote_from_bytes(_fsencode(path), safe='/')
+
+
+def unquote_trashinfo_path(value):
+    return _fsdecode(unquote_to_bytes(value))
+
+
+def _fsencode(path):
+    if hasattr(os, 'fsencode'):
+        return os.fsencode(path)
+    if isinstance(path, binary_type):
+        return path
+    if isinstance(path, text_type):
+        return path.encode(_filesystem_encoding())
+    return path
+
+
+def _fsdecode(path):
+    if hasattr(os, 'fsdecode'):
+        return os.fsdecode(path)
+    return path
+
+
+def _filesystem_encoding():
+    return sys.getfilesystemencoding() or sys.getdefaultencoding()


### PR DESCRIPTION
## Summary

Fix `.trashinfo` `Path=` handling for filenames that are valid filesystem byte sequences but not valid UTF-8.

`trash-put` can now trash files with names such as `b'\xa4-\xc8\xcf-\xc1+\xb8.txt'` without losing the original filename bytes.

## Bug

`trash-put` previously percent-encoded `Path=` from a Python text string. On Python 3, non-UTF-8 filenames are represented with surrogate escapes, and trying to encode those surrogates as UTF-8 can raise `UnicodeEncodeError` while generating the `.trashinfo` file.

This means a file can exist on disk and be passable to `os.*`, but still fail during `trash-put`.

## Reproduction

```bash
python3 - <<'PY'
import os

name = b'\xa4-\xc8\xcf-\xc1+\xb8.txt'
fd = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
os.close(fd)
print(os.fsdecode(name))
PY
```

Then pass the printed filename to:

trash-put '<printed filename>'

Before this PR, trash-put could fail while writing the .trashinfo metadata.

## Fix

This PR makes .trashinfo path encoding byte-preserving:

- Write Path= with os.fsencode(path) followed by byte-based percent encoding.
- Read Path= with byte-based percent decoding followed by os.fsdecode(...).
- Use the same helper in both parse_path() and ParseTrashInfo so list/rm/restore parse paths consistently.

This keeps .trashinfo contents UTF-8-compatible while preserving the original filesystem bytes.

## Tests

Added coverage for:

- Formatting non-UTF-8 path bytes into percent-encoded Path=.
- Parsing percent-encoded Path= back to the original filesystem bytes.
- ParseTrashInfo callback behavior for non-UTF-8 paths.
- An e2e trash-put regression test with a real non-UTF-8 filename.

Verified with:

```shell
pytest tests/test_trashcli_lib/test_parsing_trashinfo_contents.py
pytest tests/test_put/cmd/e2e
uv run --no-project --with pytest --with flexmock --with six --with psutil --with typing_extensions python -m pytest tests/test_put/cmd/test_put.py
```