### PR TITLE
Fix spelling error in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,7 +256,7 @@ If you need a trash implementation that you can checkout the `rmw`_ project.
 
 .. _rmw: https://github.com/theimpossibleastronaut/rmw
 
-If you want, can and know how to add support to BRTFS with sensibile automation
+If you want, can and know how to add support to BRTFS with sensible automation
 tests please send a pull request.
 
 Bugs


### PR DESCRIPTION
Corrected the spelling of 'sensibile' to 'sensible' in README. Grazie mille per questa utility davvero utile. Sono americano, ma parlo un po' di italiano.