### PR TITLE
Prevent restore from escaping the trash volume

### DIFF
--- a/tests/test_restore/cmd/test_restore_malformed_range.py
+++ b/tests/test_restore/cmd/test_restore_malformed_range.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+
+import pytest
+
+from tests.support.dirs.my_path import MyPath
+from tests.support.restore.restore_file_fixture import RestoreFileFixture
+from tests.support.restore.restore_user import RestoreUser
+from trashcli.fstab.volumes import FakeVolumes
+from trashcli.restore.file_system import RealFileReader, \
+    RealRestoreReadFileSystem, RealRestoreWriteFileSystem, RealListingFileSystem
+
+
+@pytest.mark.slow
+class TestRestoreMalformedRange(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = MyPath.make_temp_dir()
+        self.fixture = RestoreFileFixture(self.tmp_dir / 'XDG_DATA_HOME')
+        self.user = RestoreUser(
+            environ={'XDG_DATA_HOME': self.tmp_dir / 'XDG_DATA_HOME'},
+            uid=os.getuid(),
+            file_reader=RealFileReader(),
+            read_fs=RealRestoreReadFileSystem(),
+            write_fs=RealRestoreWriteFileSystem(),
+            listing_file_system=RealListingFileSystem(),
+            version='0.0.0',
+            volumes=FakeVolumes([]))
+
+    def test_a_range_with_two_dashes_gives_an_error_instead_of_crashing(self):
+        self.fixture.having_a_trashed_file('/foo/bar')
+
+        res = self.user.run_restore(reply='1-2-3', from_dir='/foo')
+
+        self.assertEqual('Invalid entry: not an index: 2-3\n', res.stderr)
+
+    def tearDown(self):
+        self.tmp_dir.clean_up()

--- a/tests/test_restore/cmd/test_restore_overwrite_guard.py
+++ b/tests/test_restore/cmd/test_restore_overwrite_guard.py
@@ -1,0 +1,51 @@
+import os
+import unittest
+
+import pytest
+
+from tests.support.dirs.my_path import MyPath
+from tests.support.restore.restore_file_fixture import RestoreFileFixture
+from tests.support.restore.restore_user import RestoreUser
+from trashcli.fstab.volumes import FakeVolumes
+from trashcli.restore.file_system import RealFileReader, \
+    RealRestoreReadFileSystem, RealRestoreWriteFileSystem, RealListingFileSystem
+
+
+@pytest.mark.slow
+class TestRestoreOverwriteGuard(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = MyPath.make_temp_dir()
+        self.fixture = RestoreFileFixture(self.tmp_dir / 'XDG_DATA_HOME')
+        self.cwd = self.tmp_dir / 'cwd'
+        os.makedirs(self.cwd)
+        self.user = RestoreUser(
+            environ={'XDG_DATA_HOME': self.tmp_dir / 'XDG_DATA_HOME'},
+            uid=os.getuid(),
+            file_reader=RealFileReader(),
+            read_fs=RealRestoreReadFileSystem(),
+            write_fs=RealRestoreWriteFileSystem(),
+            listing_file_system=RealListingFileSystem(),
+            version='0.0.0',
+            volumes=FakeVolumes([]))
+
+    def test_it_refuses_to_restore_over_a_dangling_symlink(self):
+        self.fixture.having_a_trashed_file(self.cwd / 'foo')
+        os.symlink(self.cwd / 'this-target-does-not-exist', self.cwd / 'foo')
+
+        res = self.user.run_restore(reply='0', from_dir=self.cwd)
+
+        self.assertEqual('Refusing to overwrite existing file "foo".\n',
+                         res.stderr)
+
+    def test_it_refuses_to_restore_onto_a_directory_even_with_overwrite(self):
+        self.fixture.having_a_trashed_file(self.cwd / 'foo')
+        os.makedirs(self.cwd / 'foo')
+
+        res = self.user.run_restore(args=['trash-restore', '--overwrite'],
+                                    reply='0', from_dir=self.cwd)
+
+        self.assertEqual('Refusing to overwrite existing file "foo".\n',
+                         res.stderr)
+
+    def tearDown(self):
+        self.tmp_dir.clean_up()

--- a/tests/test_restore/cmd/test_restore_rejects_out_of_volume_path.py
+++ b/tests/test_restore/cmd/test_restore_rejects_out_of_volume_path.py
@@ -1,0 +1,73 @@
+import collections
+import os
+import unittest
+
+from tests.support.dirs.my_path import MyPath
+from trashcli.restore.file_system import FileReader
+from trashcli.restore.trashed_files import TrashedFiles
+
+
+InfoFile = collections.namedtuple('InfoFile', 'path type volume')
+
+
+class FakeReader(FileReader):
+    def contents_of(self, path):
+        return open(path).read()
+
+
+class FakeSearcher:
+    def __init__(self, info_dir, volume):
+        self.info_dir = info_dir
+        self.volume = volume
+
+    def all_file_in_info_dir(self, trash_dir_from_cli):
+        for name in sorted(os.listdir(self.info_dir)):
+            yield InfoFile(os.path.join(self.info_dir, name), 'trashinfo',
+                           self.volume)
+
+
+class MemoLogger:
+    def __init__(self):
+        self.messages = []
+
+    def warning(self, msg):
+        self.messages.append(msg)
+
+
+class TestRestoreRejectsOutOfVolumePath(unittest.TestCase):
+    def setUp(self):
+        self.volume = MyPath.make_temp_dir()
+        self.info_dir = self.volume / '.Trash-1000' / 'info'
+        os.makedirs(self.info_dir)
+        self.logger = MemoLogger()
+        self.trashed_files = TrashedFiles(self.logger, FakeReader(),
+                                          FakeSearcher(self.info_dir,
+                                                       self.volume))
+
+    def _add(self, name, path_line):
+        with open(self.info_dir / ('%s.trashinfo' % name), 'w') as f:
+            f.write('[Trash Info]\n'
+                    'Path=%s\n'
+                    'DeletionDate=2000-01-01T00:00:00\n' % path_line)
+
+    def _restorable(self):
+        return [os.path.basename(tf.info_file)
+                for tf in self.trashed_files.all_trashed_files(None)]
+
+    def test_a_relative_path_inside_the_volume_is_restorable(self):
+        self._add('good', 'docs/report.txt')
+
+        self.assertEqual(['good.trashinfo'], self._restorable())
+
+    def test_an_absolute_path_is_not_restorable(self):
+        self._add('evil', '/etc/passwd')
+
+        self.assertEqual([], self._restorable())
+
+    def test_a_path_escaping_the_volume_is_not_restorable(self):
+        self._add('evil', '../../../etc/shadow')
+
+        self.assertEqual([], self._restorable())
+
+    def tearDown(self):
+        self.volume.clean_up()

--- a/trashcli/parse_trashinfo/parse_original_location.py
+++ b/trashcli/parse_trashinfo/parse_original_location.py
@@ -3,8 +3,17 @@ from __future__ import absolute_import
 import os
 
 from trashcli.parse_trashinfo.parse_path import parse_path
+from trashcli.parse_trashinfo.parser_error import ParseError
 
 
 def parse_original_location(contents, volume_path):
     path = parse_path(contents)
-    return os.path.join(volume_path, path)
+    resolved = os.path.normpath(os.path.join(volume_path, path))
+    if volume_path != os.path.sep:
+        # A volume trash must record a location that is relative to and inside that volume.
+        if os.path.isabs(path):
+            raise ParseError("Path= must be relative for volume trashes")
+        rel = os.path.relpath(resolved, os.path.normpath(volume_path))
+        if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+            raise ParseError("Path= escapes the volume root")
+    return resolved

--- a/trashcli/restore/file_system.py
+++ b/trashcli/restore/file_system.py
@@ -36,10 +36,22 @@ class RestoreReadFileSystem:
     def path_exists(self, path):  # type: (str) -> bool
         raise NotImplementedError()
 
+    def path_lexists(self, path):  # type: (str) -> bool
+        return self.path_exists(path)
+
+    def path_isdir(self, path):  # type: (str) -> bool
+        return False
+
 
 class RealRestoreReadFileSystem(RestoreReadFileSystem):
     def path_exists(self, path):
         return os.path.exists(path)
+
+    def path_lexists(self, path):
+        return os.path.lexists(path)
+
+    def path_isdir(self, path):
+        return os.path.isdir(path)
 
 
 @six.add_metaclass(ABCMeta)

--- a/trashcli/restore/restore_asking_the_user.py
+++ b/trashcli/restore/restore_asking_the_user.py
@@ -149,7 +149,7 @@ def parse_indexes(user_input,  # type: str
     sequences = []  # type: List[Sequence]
     for index in indexes:
         if "-" in index:
-            first, last = index.split("-", 2)
+            first, last = index.split("-", 1)
             if first == "" or last == "":
                 raise InvalidEntry("open interval: %s" % index)
             split = list(map(parse_int_index, (first, last)))

--- a/trashcli/restore/restorer.py
+++ b/trashcli/restore/restorer.py
@@ -17,16 +17,13 @@ class Restorer:
                              trashed_file, # type: TrashedFile
                              overwrite, # type: bool
                              ):
-        """
-        If overwrite is enabled, then the restore functionality will overwrite an existing file
-        """
-        if not overwrite and self.read_fs.path_exists(trashed_file.original_location):
+        """Restore the file, overwriting the destination only when overwrite is set."""
+        dest = trashed_file.original_location
+        # lexists() also sees a dangling symlink, and a file must never be merged onto a directory.
+        if self.read_fs.path_lexists(dest) and (
+                not overwrite or self.read_fs.path_isdir(dest)):
             raise IOError(
-                'Refusing to overwrite existing file "%s".' % os.path.basename(
-                    trashed_file.original_location))
-        else:
-            parent = os.path.dirname(trashed_file.original_location)
-            self.write_fs.mkdirs(parent)
-
-        self.write_fs.move(trashed_file.original_file, trashed_file.original_location)
+                'Refusing to overwrite existing file "%s".' % os.path.basename(dest))
+        self.write_fs.mkdirs(os.path.dirname(dest))
+        self.write_fs.move(trashed_file.original_file, dest)
         self.write_fs.remove_file(trashed_file.info_file)


### PR DESCRIPTION
- reject Path= entries that are absolute or escape the volume root. A crafted trashinfo can no longer overwrite files outside the trash volume
- refuse to restore onto a dangling symlink (the old existence check missed it)
- refuse to restore a file onto an existing directory even with --overwrite
- fix crash on index ranges like "1-2-3" (split once, not twice)