### PR TITLE
Harden trash-put against unwritable dirs

### DIFF
--- a/tests/test_put/cmd/test_put_option_shaped_filename.py
+++ b/tests/test_put/cmd/test_put_option_shaped_filename.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+
+from tests.support.dirs.my_path import MyPath
+from trashcli.put.parser import Parser, ExitWithCode, Trash
+
+
+class TestPutOptionShapedFilename(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = MyPath.make_temp_dir()
+        self.old_cwd = os.getcwd()
+        os.chdir(self.tmp_dir)
+        self.parser = Parser()
+
+    def test_it_refuses_an_existing_file_that_looks_like_an_option(self):
+        open('--trash-dir=evil', 'w').close()
+
+        result = self.parser.parse_args(['trash-put', '--trash-dir=evil'])
+
+        self.assertIs(result.type, ExitWithCode)
+        self.assertNotEqual(0, result.exit_code)
+
+    def test_the_double_dash_separator_still_lets_you_trash_such_a_file(self):
+        open('--trash-dir=evil', 'w').close()
+
+        result = self.parser.parse_args(
+            ['trash-put', '--', '--trash-dir=evil'])
+
+        self.assertIs(result.type, Trash)
+        self.assertEqual(['--trash-dir=evil'], result.files)
+
+    def test_a_real_option_is_unaffected_when_no_such_file_exists(self):
+        open('foo', 'w').close()
+
+        result = self.parser.parse_args(
+            ['trash-put', '--trash-dir=/tmp/dir', 'foo'])
+
+        self.assertIs(result.type, Trash)
+        self.assertEqual('/tmp/dir', result.trash_dir)
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        self.tmp_dir.clean_up()

--- a/tests/test_put/cmd/test_put_symlinked_trash_dir.py
+++ b/tests/test_put/cmd/test_put_symlinked_trash_dir.py
@@ -1,0 +1,37 @@
+from six import StringIO
+
+from tests.support.put.dummy_clock import FixedClock, jan_1st_2024
+from tests.support.put.fake_fs.failing_fake_fs import FailingFakeFs
+from tests.support.put.fake_random import FakeRandomInt
+from tests.test_put.support.recording_backend import RecordingBackend
+from tests.test_put.support.result import Result
+from trashcli.lib.my_input import HardCodedInput
+from trashcli.put.main import make_cmd
+from trashcli.put.parser import ensure_int
+
+
+class TestPutSymlinkedTrashDir:
+    def setup_method(self):
+        self.fs = FailingFakeFs()
+        self.user_input = HardCodedInput('y')
+        self.randint = FakeRandomInt([])
+
+    def test_it_does_not_trash_into_a_symlinked_info_dir(self):
+        self.fs.touch("/foo")
+        self.fs.makedirs("/.Trash-123", 0o700)
+        self.fs.symlink("/somewhere-else", "/.Trash-123/info")
+
+        self.run_cmd(['trash-put', '/foo'])
+
+        assert self.fs.exists("/foo")
+        assert not self.fs.exists('/.Trash-123/files')
+
+    def run_cmd(self, args):
+        stderr = StringIO()
+        backend = RecordingBackend(stderr)
+        cmd = make_cmd(clock=FixedClock(jan_1st_2024()), fs=self.fs,
+                       user_input=self.user_input, randint=self.randint,
+                       backend=backend)
+        exit_code = cmd.run_put(args, {}, 123)
+        return Result(stderr.getvalue().splitlines(), "",
+                      ensure_int(exit_code), backend.collected())

--- a/tests/test_restore/cmd/test_restore_owner_check.py
+++ b/tests/test_restore/cmd/test_restore_owner_check.py
@@ -1,0 +1,67 @@
+import collections
+import os
+import unittest
+
+from tests.support.dirs.my_path import MyPath
+from tests.support.py2mock import patch
+from trashcli.restore.file_system import FileReader
+from trashcli.restore.trashed_files import TrashedFiles
+
+
+InfoFile = collections.namedtuple('InfoFile', 'path type volume')
+
+
+class FakeReader(FileReader):
+    def contents_of(self, path):
+        return open(path).read()
+
+
+class FakeSearcher:
+    def __init__(self, info_dir):
+        self.info_dir = info_dir
+
+    def all_file_in_info_dir(self, trash_dir_from_cli):
+        for name in sorted(os.listdir(self.info_dir)):
+            yield InfoFile(os.path.join(self.info_dir, name), 'trashinfo', '/')
+
+
+class MemoLogger:
+    def __init__(self):
+        self.messages = []
+
+    def warning(self, msg):
+        self.messages.append(msg)
+
+
+class TestRestoreOwnerCheck(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = MyPath.make_temp_dir()
+
+    def _trashed_files_in(self, mode):
+        info_dir = self.tmp_dir / ('trash-%o' % mode) / 'info'
+        os.makedirs(info_dir)
+        os.chmod(info_dir, mode)
+        with open(info_dir / 'x.trashinfo', 'w') as f:
+            f.write('[Trash Info]\nPath=/foo/x\n'
+                    'DeletionDate=2000-01-01T00:00:00\n')
+        return TrashedFiles(MemoLogger(), FakeReader(), FakeSearcher(info_dir))
+
+    def _restorable(self, trashed_files):
+        return [os.path.basename(tf.info_file)
+                for tf in trashed_files.all_trashed_files(None)]
+
+    def test_foreign_owned_entry_is_hidden_in_a_world_writable_dir(self):
+        trashed_files = self._trashed_files_in(0o1777)
+
+        # pretend we run as a user who does not own the (root-owned) trashinfo
+        with patch('os.geteuid', return_value=os.getuid() + 4242):
+            self.assertEqual([], self._restorable(trashed_files))
+
+    def test_foreign_owned_entry_is_kept_in_a_private_dir(self):
+        trashed_files = self._trashed_files_in(0o700)
+
+        with patch('os.geteuid', return_value=os.getuid() + 4242):
+            self.assertEqual(['x.trashinfo'], self._restorable(trashed_files))
+
+    def tearDown(self):
+        self.tmp_dir.clean_up()

--- a/trashcli/put/janitor_tools/security_check.py
+++ b/trashcli/put/janitor_tools/security_check.py
@@ -12,6 +12,9 @@ class SecurityCheck:
     def check_trash_dir_is_secure(self,
                                   candidate,  # type: Candidate
                                   ):  # type: (...) -> Either[None, FailureReason]
+        for sub_dir in (candidate.info_dir(), candidate.files_dir()):
+            if self.fs.lexists(sub_dir) and self.fs.islink(sub_dir):
+                return Left(TrashDirIsNotSecureBecauseSymLink())
         if candidate.check_type == NoCheck:
             return Right(None)
         if candidate.check_type == TopTrashDirCheck:

--- a/trashcli/put/parser.py
+++ b/trashcli/put/parser.py
@@ -39,6 +39,11 @@ class Parser:
         program_name = os.path.basename(argv[0])
         arg_parser = make_parser(program_name)
         try:
+            bad = option_shaped_existing_files(argv[1:])
+            if bad:
+                arg_parser.error(
+                    "refusing to treat existing file %s as an option "
+                    "(use './%s' or a '--' separator)" % (bad[0], bad[0]))
             options = arg_parser.parse_args(argv[1:])
             if len(options.files) <= 0:
                 arg_parser.error("Please specify the files to trash.")
@@ -54,6 +59,18 @@ class Parser:
                      forced_volume=options.forced_volume,
                      verbose=options.verbose,
                      home_fallback=options.home_fallback)
+
+
+def option_shaped_existing_files(args):
+    result = []
+    after_separator = False
+    for arg in args:
+        if arg == '--':
+            after_separator = True
+        elif not after_separator and arg.startswith('-') and arg != '-' \
+                and os.path.lexists(arg):
+            result.append(arg)
+    return result
 
 
 def ensure_int(code):

--- a/trashcli/restore/trashed_files.py
+++ b/trashcli/restore/trashed_files.py
@@ -3,6 +3,9 @@ from typing import NamedTuple
 from typing import Optional
 from typing import Union
 
+import os
+import stat
+
 from trashcli.lib.path_of_backup_copy import path_of_backup_copy
 from trashcli.parse_trashinfo.parse_deletion_date import parse_deletion_date
 from trashcli.parse_trashinfo.parse_original_location import \
@@ -47,6 +50,10 @@ class TrashedFiles:
             if info_file.type == 'non_trashinfo':
                 yield NonTrashinfoFileFound(info_file.path)
             elif info_file.type == 'trashinfo':
+                if foreign_owner_in_shared_dir(info_file.path):
+                    yield NonParsableTrashInfo(info_file.path, ValueError(
+                        "owned by another user in a world-writable trash dir"))
+                    continue
                 try:
                     contents = self.file_reader.contents_of(info_file.path)
                     original_location = parse_original_location(contents,
@@ -98,3 +105,16 @@ Event = Union[
     TrashedFileFound,
     NonParsableTrashInfo,
     IOErrorReadingTrashInfo]
+
+
+def foreign_owner_in_shared_dir(info_path):
+    if not hasattr(os, 'geteuid'):
+        return False
+    try:
+        euid = os.geteuid()
+        if euid == 0 or os.lstat(info_path).st_uid == euid:
+            return False
+        # Only distrust a foreign-owned entry when the trash dir is world-writable (shared).
+        return bool(os.stat(os.path.dirname(info_path)).st_mode & stat.S_IWOTH)
+    except OSError:
+        return False


### PR DESCRIPTION
- refuse to treat an existing option-shaped file (e.g. --trash-dir=x) as an
  option. "trash-put *" cannot be hijacked into trashing to another dir anymore
- reject a trash dir whose info/ or files/ is a symlink
- stop trashinfo creation from looping forever on an unwritable or full dir.  fail fast on EACCES/EPERM/ENOSPC/EDQUOT/EROFS, cap retries otherwise
- on failure trash-put stops cleanly and leaves the original file in place
- only hide foreign-owned trashinfo in world-writable (shared) trash dirs. Now your own files stay restorable when uids differ (NFS, backups, cross-OS)