### PR TITLE
trash-put: refactor, removed duplication shared between test_persist_trashinfo.py and janitor.py.

### DIFF
--- a/tests/test_put/components/test_persist_trashinfo.py
+++ b/tests/test_put/components/test_persist_trashinfo.py
@@ -49,4 +49,4 @@ class TestPersistTrashInfo(unittest.TestCase):
     def _persist_trash_info(self, basename, content):
         log_data = LogData('trash-cli', 2)
         data = TrashinfoData(basename, content, self.path)
-        return self.info_dir.create_trashinfo_file(data, log_data).trashinfo_path
+        return self.info_dir.persist(data, log_data).trashinfo_path

--- a/trashcli/put/janitor.py
+++ b/trashcli/put/janitor.py
@@ -1,29 +1,23 @@
 from typing import NamedTuple, TypeVar
 
-from trashcli.put.suffix import Suffix
-
-from trashcli.put.core.int_generator import IntGenerator
-
-from trashcli.put.my_logger import LoggerBackend
-
-from trashcli.put.clock import PutClock
-
 from trashcli.lib.environ import Environ
+from trashcli.put.clock import PutClock
 from trashcli.put.core.candidate import Candidate
 from trashcli.put.core.either import Left
 from trashcli.put.core.failure_reason import FailureReason, LogContext
+from trashcli.put.core.int_generator import IntGenerator
 from trashcli.put.core.trashee import Trashee
 from trashcli.put.fs.fs import Fs
 from trashcli.put.janitor_tools.info_creator import TrashInfoCreator
-from trashcli.put.janitor_tools.info_file_persister import InfoFilePersister, \
-    TrashedFile
+from trashcli.put.janitor_tools.info_file_persister import InfoFilePersister
 from trashcli.put.janitor_tools.put_trash_dir import PutTrashDir
 from trashcli.put.janitor_tools.security_check import SecurityCheck
 from trashcli.put.janitor_tools.trash_dir_checker import TrashDirChecker
 from trashcli.put.janitor_tools.trash_dir_creator import TrashDirCreator
-from trashcli.put.jobs import JobExecutor
 from trashcli.put.my_logger import LogData
+from trashcli.put.my_logger import LoggerBackend
 from trashcli.put.my_logger import MyLogger
+from trashcli.put.suffix import Suffix
 
 
 class NoLog(FailureReason):
@@ -44,8 +38,7 @@ class Janitor:
         self.security_check = SecurityCheck(fs)
         self.persister = InfoFilePersister(fs, MyLogger(backend), Suffix(randint))
         self.dir_creator = TrashDirCreator(fs)
-        self.executor = JobExecutor(MyLogger(backend), TrashedFile)
-
+        self.logger = MyLogger(backend)
 
     class Result(NamedTuple('Result', [
         ('ok', bool),
@@ -78,8 +71,9 @@ class Janitor:
         if isinstance(trashinfo_data, Left):
             return make_error(trashinfo_data)
 
-        persisting_job = self.persister.try_persist(trashinfo_data.value())
-        trashed_file = self.executor.execute(persisting_job, log_data)
+        trashed_file = self.persister.persist(trashinfo_data.value(),
+                                              log_data)
+
         trashed = self.trash_dir.try_trash(trashee.path, trashed_file)
         if isinstance(trashed, Left):
             return make_error(trashed)

--- a/trashcli/put/janitor_tools/info_file_persister.py
+++ b/trashcli/put/janitor_tools/info_file_persister.py
@@ -32,16 +32,27 @@ class InfoFilePersister:
                  logger,  # type: MyLogger
                  suffix,  # type: Suffix
                  ):  # type: (...) -> None
+        self.logger = logger
+        self.persist_loop = PersistLoop(fs, logger, suffix)
+
+    def persist(self,
+                trash_info_data,  # type: TrashinfoData
+                log_data,  # type: LogData
+                ):  # (...) -> TrashedFile
+        persisting_job = self.persist_loop.try_persist(trash_info_data)
+        job_executor = JobExecutor(self.logger, TrashedFile)
+        return job_executor.execute(persisting_job, log_data)
+
+
+class PersistLoop:
+    def __init__(self,
+                 fs,  # type: Fs
+                 logger,  # type: MyLogger
+                 suffix,  # type: Suffix
+                 ):  # type: (...) -> None
         self.fs = fs
         self.logger = logger
         self.suffix = suffix
-
-    def create_trashinfo_file(self,
-                              trashinfo_data,  # type: TrashinfoData
-                              log_data,  # type: LogData
-                              ):  # type: (...) -> TrashedFile
-        return JobExecutor(self.logger, TrashedFile).execute(
-            self.try_persist(trashinfo_data), log_data)
 
     Result = Iterator[JobStatus[TrashedFile]]
 


### PR DESCRIPTION
Just a refactor started when I read the work by @curious-rabbit proposted in PR https://github.com/andreafrancia/trash-cli/pull/394

