### PR TITLE
Harden trash-put against unwritable dirs with tests.

### DIFF
--- a/tests/support/put/fake_fs/failing_fake_fs.py
+++ b/tests/support/put/fake_fs/failing_fake_fs.py
@@ -7,15 +7,24 @@ class FailingOnAtomicWriteFakeFs(FakeFs):
         super(FailingOnAtomicWriteFakeFs, self).__init__()
         self._atomic_write_can_fail = False
         self._atomic_write_failure_stop = None
+        self._atomic_write_errno = None
 
     def fail_atomic_create_unless(self, basename):
         self._atomic_write_can_fail = True
         self._atomic_write_failure_stop = basename
 
+    def fail_atomic_write_with_errno(self, errno_value):
+        self._atomic_write_can_fail = True
+        self._atomic_write_failure_stop = None
+        self._atomic_write_errno = errno_value
+
     def atomic_write(self,
                      path,
                      content):
         if self._atomic_write_is_supposed_to_fail(path):
+            if self._atomic_write_errno is not None:
+                raise OSError(self._atomic_write_errno,
+                              os.strerror(self._atomic_write_errno))
             raise OSError("atomic_write failed")
 
         return super(FailingOnAtomicWriteFakeFs, self).atomic_write(path,

--- a/tests/test_put/cmd/test_put_unwritable_trash_dir.py
+++ b/tests/test_put/cmd/test_put_unwritable_trash_dir.py
@@ -1,0 +1,56 @@
+import errno
+
+from six import StringIO
+
+from tests.support.put.dummy_clock import FixedClock, jan_1st_2024
+from tests.support.put.fake_fs.failing_fake_fs import FailingFakeFs
+from tests.support.put.fake_random import FakeRandomInt
+from tests.test_put.support.recording_backend import RecordingBackend
+from tests.test_put.support.result import Result
+from trashcli.lib.exit_codes import EX_IOERR
+from trashcli.lib.my_input import HardCodedInput
+from trashcli.put.main import make_cmd
+from trashcli.put.parser import ensure_int
+
+
+class TestPutUnwritableTrashDir:
+    def setup_method(self):
+        self.fs = FailingFakeFs()
+        self.user_input = HardCodedInput('y')
+        self.randint = FakeRandomInt([])
+
+    def test_it_reports_an_error_when_the_trashinfo_cannot_be_written(self):
+        self.fs.touch("/foo")
+        self.fs.fail_atomic_write_with_errno(errno.EACCES)
+
+        result = self.run_cmd(['trash-put', '/foo'])
+
+        assert result.exit_code == EX_IOERR
+        assert any('Permission denied' in line for line in result.stderr), \
+            result.stderr
+
+    def test_it_leaves_the_original_file_in_place_on_failure(self):
+        self.fs.touch("/foo")
+        self.fs.fail_atomic_write_with_errno(errno.EACCES)
+
+        self.run_cmd(['trash-put', '/foo'])
+
+        assert self.fs.exists("/foo")
+
+    def test_it_does_not_move_the_file_into_the_trash_on_failure(self):
+        self.fs.touch("/foo")
+        self.fs.fail_atomic_write_with_errno(errno.EROFS)
+
+        self.run_cmd(['trash-put', '/foo'])
+
+        assert self.fs.ls_aa('/.Trash-123/files') == []
+
+    def run_cmd(self, args):
+        stderr = StringIO()
+        backend = RecordingBackend(stderr)
+        cmd = make_cmd(clock=FixedClock(jan_1st_2024()), fs=self.fs,
+                       user_input=self.user_input, randint=self.randint,
+                       backend=backend)
+        exit_code = cmd.run_put(args, {}, 123)
+        return Result(stderr.getvalue().splitlines(), "",
+                      ensure_int(exit_code), backend.collected())

--- a/trashcli/put/janitor.py
+++ b/trashcli/put/janitor.py
@@ -31,6 +31,14 @@ class NoLog(FailureReason):
         return ""
 
 
+class UnableToPersistTrashinfo(FailureReason):
+    def __init__(self, error):
+        self.error = error
+
+    def log_entries(self, context):  # type: (LogContext) -> str
+        return "failed to create trashinfo file: %s" % self.error
+
+
 class Janitor:
     def __init__(self,
                  fs,  # type: Fs
@@ -79,7 +87,10 @@ class Janitor:
             return make_error(trashinfo_data)
 
         persisting_job = self.persister.try_persist(trashinfo_data.value())
-        trashed_file = self.executor.execute(persisting_job, log_data)
+        try:
+            trashed_file = self.executor.execute(persisting_job, log_data)
+        except OSError as e:
+            return Janitor.Result(False, UnableToPersistTrashinfo(e))
         trashed = self.trash_dir.try_trash(trashee.path, trashed_file)
         if isinstance(trashed, Left):
             return make_error(trashed)

--- a/trashcli/put/janitor_tools/info_file_persister.py
+++ b/trashcli/put/janitor_tools/info_file_persister.py
@@ -9,6 +9,12 @@ from trashcli.put.jobs import JobStatus, NeedsMoreAttempts, Succeeded, \
 from trashcli.put.my_logger import LogData, MyLogger
 from trashcli.put.suffix import Suffix
 
+# Errors that retrying with another suffix in the same directory can never fix.
+HARD_ERRNOS = frozenset(
+    code for code in (getattr(errno, name, None)
+                      for name in ('EACCES', 'EPERM', 'ENOSPC', 'EDQUOT', 'EROFS'))
+    if code is not None)
+
 
 class TrashinfoData(NamedTuple('TrashinfoData', [
     ('basename', str),
@@ -50,6 +56,7 @@ class InfoFilePersister:
                     ):  # type: (...) -> Result
         index = 0
         name_too_long = False
+        # No arbitrary cap: a permanent write error (see HARD_ERRNOS) stops the loop.
         while True:
             suffix = self.suffix.suffix_for_index(index)
             trashinfo_basename = create_trashinfo_basename(data.basename,
@@ -64,9 +71,12 @@ class InfoFilePersister:
                 self.fs.atomic_write(trashinfo_path, data.content)
                 yield Succeeded(TrashedFile(trashinfo_path),
                                 ".trashinfo created as %s." % trashinfo_path)
+                return
             except OSError as e:
                 if e.errno == errno.ENAMETOOLONG:
                     name_too_long = True
+                elif e.errno in HARD_ERRNOS:
+                    raise
                 yield NeedsMoreAttempts(trashinfo_path,
                                         "attempt for creating %s failed." % trashinfo_path)
 


### PR DESCRIPTION
This pull request is the result of separating the handing of unwritable info dir proposted by @curious-rabbit in https://github.com/andreafrancia/trash-cli/pull/394

I need to exclude only one part to review it well.