### PR TITLE
support file names that are not valid UTF-8

### DIFF
--- a/tests/test_put/components/test_format_trash_info.py
+++ b/tests/test_put/components/test_format_trash_info.py
@@ -1,0 +1,24 @@
+import unittest
+
+from trashcli.compat import fsdecode
+from trashcli.parse_trashinfo.parse_path import parse_path
+from trashcli.put.format_trash_info import format_original_location
+
+# this is how a file name with the raw byte 0xff reaches python
+bad_name = fsdecode(b'/foo/bad\xffname')
+
+
+class TestFormatOriginalLocation(unittest.TestCase):
+    def test_plain_name(self):
+        assert format_original_location('/foo/bar') == '/foo/bar'
+
+    def test_name_with_spaces(self):
+        assert format_original_location('/foo/a file') == '/foo/a%20file'
+
+    def test_name_with_a_byte_that_is_not_valid_text(self):
+        assert format_original_location(bad_name) == '/foo/bad%FFname'
+
+    def test_round_trip_keeps_the_name_unchanged(self):
+        contents = 'Path=%s\n' % format_original_location(bad_name)
+
+        assert parse_path(contents) == bad_name

--- a/tests/test_trashcli_lib/test_printable.py
+++ b/tests/test_trashcli_lib/test_printable.py
@@ -1,0 +1,15 @@
+import unittest
+
+from trashcli.compat import fsdecode
+from trashcli.lib.printable import printable
+
+
+class TestPrintable(unittest.TestCase):
+    def test_plain_text_is_unchanged(self):
+        assert printable('/foo/bar baz') == '/foo/bar baz'
+
+    def test_valid_non_ascii_text_is_unchanged(self):
+        assert printable(u'/foo/caf\xe9') == u'/foo/caf\xe9'
+
+    def test_raw_bytes_are_shown_as_escapes(self):
+        assert printable(fsdecode(b'bad\xffname')) == 'bad\\xffname'

--- a/trashcli/compat.py
+++ b/trashcli/compat.py
@@ -1,3 +1,6 @@
+import sys
+
+
 def protocol():
     try:
         from typing import Protocol
@@ -10,3 +13,15 @@ def protocol():
 Protocol = protocol()
 
 del protocol
+
+if sys.version_info[0] >= 3:
+    # python 3: go between str paths and their raw bytes
+    from os import fsencode
+    from os import fsdecode
+else:
+    # python 2: paths are plain byte strings already
+    def fsencode(path):
+        return path
+
+    def fsdecode(path):
+        return path

--- a/trashcli/lib/printable.py
+++ b/trashcli/lib/printable.py
@@ -1,0 +1,20 @@
+def printable(text):  # type: (str) -> str
+    # make a text safe to print on any terminal
+    if isinstance(text, bytes):
+        # python 2 byte strings go out unchanged
+        return text
+    try:
+        text.encode('utf-8')
+        return text
+    except UnicodeEncodeError:
+        text = ''.join(_escape_raw_byte(c) for c in text)
+        # last resort for any other char the stream can not take
+        return text.encode('utf-8', 'backslashreplace').decode('utf-8')
+
+
+def _escape_raw_byte(c):  # type: (str) -> str
+    cp = ord(c)
+    if 0xdc80 <= cp <= 0xdcff:
+        # a lone surrogate stands for one raw byte, show that byte
+        return '\\x%02x' % (cp - 0xdc00)
+    return c

--- a/trashcli/list/list_trash_action.py
+++ b/trashcli/list/list_trash_action.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 
 from trashcli.lib.dir_reader import DirReader
 from trashcli.lib.path_of_backup_copy import path_of_backup_copy
+from trashcli.lib.printable import printable
 from trashcli.lib.sanitize import shell_escape, quoting_wanted
 from trashcli.lib.trash_dir_reader import TrashDirReader
 from trashcli.list.extractors import DeletionDateExtractor
@@ -66,9 +67,9 @@ class ListTrashAction:
 
     def print_event(self, event):
         if isinstance(event, Error):
-            print(event.error, file=self.err)
+            print(printable(event.error), file=self.err)
         elif isinstance(event, Output):
-            print(event.message, file=self.out)
+            print(printable(event.message), file=self.out)
 
 
 class ListTrash:

--- a/trashcli/parse_trashinfo/parse_path.py
+++ b/trashcli/parse_trashinfo/parse_path.py
@@ -1,12 +1,25 @@
 from __future__ import absolute_import
 
-from six.moves.urllib.parse import unquote
+import sys
 
+from trashcli.compat import fsdecode
 from trashcli.parse_trashinfo.parser_error import ParseError
+
+if sys.version_info[0] >= 3:
+    # python 3: unquote to raw bytes so no byte gets lost
+    from urllib.parse import unquote_to_bytes
+else:
+    # python 2: plain unquote already works on byte strings
+    from urllib import unquote as unquote_to_bytes
+
+
+def unquote_path(quoted_path):  # type: (str) -> str
+    # go through bytes so any file name comes back unchanged
+    return fsdecode(unquote_to_bytes(quoted_path))
 
 
 def parse_path(contents):
     for line in contents.split('\n'):
         if line.startswith('Path='):
-            return unquote(line[len('Path='):])
+            return unquote_path(line[len('Path='):])
     raise ParseError('Unable to parse Path')

--- a/trashcli/parse_trashinfo/parse_trashinfo.py
+++ b/trashcli/parse_trashinfo/parse_trashinfo.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
 import datetime
-from six.moves.urllib.parse import unquote
+
+from trashcli.parse_trashinfo.parse_path import unquote_path
 
 
 def do_nothing(*argv, **argvk): pass
@@ -30,5 +31,5 @@ class ParseTrashInfo:
                     self.found_deletion_date(date)
 
             if line.startswith('Path='):
-                path = unquote(line[len('Path='):])
+                path = unquote_path(line[len('Path='):])
                 self.found_path(path)

--- a/trashcli/put/format_trash_info.py
+++ b/trashcli/put/format_trash_info.py
@@ -2,6 +2,8 @@ import datetime
 
 from six.moves.urllib.parse import quote as url_quote
 
+from trashcli.compat import fsencode
+
 
 def format_trashinfo(original_location,  # type: str
                      deletion_date,  # type: datetime.datetime
@@ -17,4 +19,5 @@ def format_date(deletion_date):  # type: (datetime.datetime) -> str
 
 
 def format_original_location(original_location):  # type: (str) -> str
-    return url_quote(original_location, '/')
+    # quote the raw bytes so any file name can be stored
+    return url_quote(fsencode(original_location), '/')

--- a/trashcli/restore/real_output.py
+++ b/trashcli/restore/real_output.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import six
 
+from trashcli.lib.printable import printable
 from trashcli.restore.output import Output
 from trashcli.restore.output_event import Println, Die, Quit, Exiting, \
     OutputEvent
@@ -17,10 +18,10 @@ class RealOutput(Output):
         self.die('')
 
     def printerr(self, msg):
-        print(six.text_type(msg), file=self.stderr)
+        print(printable(six.text_type(msg)), file=self.stderr)
 
     def println(self, line):
-        print(six.text_type(line), file=self.stdout)
+        print(printable(six.text_type(line)), file=self.stdout)
 
     def die(self, error):
         self.printerr(error)


### PR DESCRIPTION
trash-put crashed with UnicodeEncodeError on any file name that is not valid UTF-8. Such names are legal on Linux.

With this patch the Path value is percent-encoded from the raw bytes and decoded back the same way, so put, list, rm and restore keep the exact name. Output code escapes bytes that a stream can not take, so trash-list and trash-restore print such names instead of crashing.