### PR TITLE
stop crashing rm on an empty pattern

### DIFF
--- a/tests/test_rm/cmd/test_trash_rm.py
+++ b/tests/test_rm/cmd/test_trash_rm.py
@@ -29,6 +29,13 @@ class TestTrashRmCmdRun(unittest.TestCase):
         assert_starts_with(self.stderr.getvalue(),
                            'Usage:\n    trash-rm PATTERN\n\nPlease specify PATTERN.\n')
 
+    def test_with_empty_pattern(self):
+        self.cmd.run([None, ''], uid=None)
+
+        assert_starts_with(self.stderr.getvalue(),
+                           'Usage:\n    trash-rm PATTERN\n')
+        assert self.cmd.exit_code == 8
+
     def test_without_pattern_argument(self):
         self.volumes_listing.list_volumes.return_value = ['/vol1']
 

--- a/tests/test_rm/cmd/test_trash_rm.py
+++ b/tests/test_rm/cmd/test_trash_rm.py
@@ -36,6 +36,13 @@ class TestTrashRmCmdRun(unittest.TestCase):
                            'Usage:\n    trash-rm PATTERN\n')
         assert self.cmd.exit_code == 8
 
+    def test_with_too_many_arguments(self):
+        self.cmd.run([None, '*.o', 'other.o'], uid=None)
+
+        assert_starts_with(self.stderr.getvalue(),
+                           'trash-rm: too many arguments\n')
+        assert self.cmd.exit_code == 8
+
     def test_without_pattern_argument(self):
         self.volumes_listing.list_volumes.return_value = ['/vol1']
 

--- a/tests/test_rm/components/test_filter.py
+++ b/tests/test_rm/components/test_filter.py
@@ -31,6 +31,12 @@ class TestFilter(unittest.TestCase):
         assert self.cmd.matches('/foo/bar.baz') == True
         assert self.cmd.matches('/foo/bar') == False
 
+    def test_empty_pattern_matches_nothing_and_does_not_crash(self):
+        self.cmd = Filter('')
+
+        assert self.cmd.matches('foo') == False
+        assert self.cmd.matches('/foo/bar') == False
+
     def test(self):
         self.cmd = Filter('/foo/*.baz')
 

--- a/trashcli/rm/filter.py
+++ b/trashcli/rm/filter.py
@@ -9,5 +9,7 @@ class Filter:
 
     def matches(self, original_location):
         basename = os.path.basename(original_location)
-        subject = original_location if self.pattern[0] == '/' else basename
+        # a pattern that starts with / matches the full original path
+        subject = original_location if self.pattern.startswith('/') \
+            else basename
         return fnmatch.fnmatchcase(subject, self.pattern)

--- a/trashcli/rm/rm_cmd.py
+++ b/trashcli/rm/rm_cmd.py
@@ -38,7 +38,7 @@ class RmCmd:
         args = argv[1:]
         self.exit_code = 0
 
-        if not args:
+        if not args or args[0] == '':
             self.print_err('Usage:\n'
                            '    trash-rm PATTERN\n'
                            '\n'

--- a/trashcli/rm/rm_cmd.py
+++ b/trashcli/rm/rm_cmd.py
@@ -47,6 +47,13 @@ class RmCmd:
             self.exit_code = 8
             return
 
+        if len(args) > 1:
+            # more than one argument usually means the shell expanded the pattern
+            self.print_err('trash-rm: too many arguments\n'
+                           'Note: quote the pattern to stop the shell from expanding it, e.g. trash-rm "*.o"')
+            self.exit_code = 8
+            return
+
         trashcan = CleanableTrashcan(FileRemover())
         cmd = Filter(args[0])
 


### PR DESCRIPTION
trash-rm raised IndexError from pattern[0], because an empty argument list check does not catch an empty string argument.


trash-rm also used only the first argument and dropped the rest in silence, so an unquoted glob like trash-rm *.o removed the wrong entry after shell expansion.  

Now an empty pattern or extra arguments shows the usage message and exits with code 8 and the filter itself no longer indexes into the pattern.