### PR TITLE
trash-empty: remove files without write bit

### DIFF
--- a/tests/test_empty/cmd/test_empty_cmd_fs.py
+++ b/tests/test_empty/cmd/test_empty_cmd_fs.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2011-2022 Andrea Francia Bereguardo(PV) Italy
+import os
+import stat
 import unittest
 
 import pytest
@@ -50,4 +52,38 @@ class TestTrashEmptyCmdFs(unittest.TestCase):
 
     def tearDown(self):
         make_readable(self.unreadable_dir)
+        self.tmp_dir.clean_up()
+
+
+class TestTrashEmptyRemovesReadonlyDir:
+    def setup_method(self):
+        self.tmp_dir = MyPath.make_temp_dir()
+        self.trash_files = self.tmp_dir / 'data/Trash/files'
+        volumes_listing = Mock(spec=VolumesListing)
+        volumes_listing.list_volumes.return_value = [self.trash_files]
+        self.err = StringIO()
+        self.environ = {'XDG_DATA_HOME': self.tmp_dir / 'data'}
+        self.empty = EmptyCmd(
+            argv0='trash-empty', out=StringIO(), err=self.err,
+            volumes_listing=volumes_listing, now=None,
+            file_reader=RealTopTrashDirRulesReader(),
+            file_remover=ExistingFileRemover(),
+            content_reader=FileSystemContentReader(),
+            dir_reader=FileSystemDirReader(), version='unused',
+            volumes=StubVolumeOf())
+
+    def test_a_directory_without_write_permission_is_removed(self):
+        target = self.trash_files / 'proj'
+        os.makedirs(target / 'sub')
+        with open(target / 'sub' / 'f', 'w') as f:
+            f.write('x')
+        os.chmod(target / 'sub', stat.S_IRUSR | stat.S_IXUSR)
+        os.chmod(target, stat.S_IRUSR | stat.S_IXUSR)
+
+        self.empty.run_cmd([], self.environ, uid=123)
+
+        assert not os.path.exists(target)
+        assert self.err.getvalue() == ""
+
+    def teardown_method(self):
         self.tmp_dir.clean_up()

--- a/trashcli/fs.py
+++ b/trashcli/fs.py
@@ -137,7 +137,20 @@ class RealRemoveFile2(RemoveFile2):
         try:
             os.remove(path)
         except OSError:
-            shutil.rmtree(path)
+            try:
+                shutil.rmtree(path)
+            except OSError:
+                _add_write_permission(path)
+                shutil.rmtree(path)
+
+
+def _add_write_permission(path):
+    # add write and search bits to owned directories so their entries can be removed; an unreadable directory is left as is and still reported
+    for root, dirs, files in os.walk(path):
+        try:
+            os.chmod(root, os.stat(root).st_mode | stat.S_IWUSR | stat.S_IXUSR)
+        except OSError:
+            pass
 
 
 class RealRemoveFileIfExists(RemoveFileIfExists, RemoveFile2):


### PR DESCRIPTION
A directory in the trash can lack its write bit. Removing a directory needs the write bit to delete the entries inside it, so trash-empty stopped with "cannot remove" and left the directory, although the user owns it.

trash-empty now adds the write and search bits to the directories it owns before removing them. A directory that cannot even be listed (no read bit) is still left in place and reported.

    $ trash-put ~/project
    $ chmod -w ~/.local/share/Trash/files/project
    $ trash-empty
    trash-empty: cannot remove /home/user/.local/share/Trash/files/project