### PR TITLE
restore: continue selected batch after file errors

### DIFF
--- a/tests/test_restore/cmd/test_restore2.py
+++ b/tests/test_restore/cmd/test_restore2.py
@@ -66,6 +66,47 @@ class TestRestore2(unittest.TestCase):
 
         assert res.last_line_of_stdout() == 'No files were restored'
 
+    def test_batch_restore_continues_after_conflicts(self):
+        for name in ['a.txt', 'b.txt', 'c.txt', 'd.txt']:
+            self.fs.add_trash_file('/cwd/' + name, '/data_home/Trash',
+                                   datetime.datetime(2016, 1, 1), 'trashed')
+        self.fs.add_file('/cwd/b.txt')
+        self.fs.add_file('/cwd/d.txt')
+
+        res = self.cmd_run(['trash-restore', '--sort=path'],
+                           reply='0-3', from_dir='/cwd')
+
+        assert 1 == res.exit_code
+        assert ('Refusing to overwrite existing file "b.txt".\n'
+                'Refusing to overwrite existing file "d.txt".\n') == res.stderr
+        assert [
+            call.mkdirs('/cwd'),
+            call.move('/data_home/Trash/files/a.txt', '/cwd/a.txt'),
+            call.remove_file('/data_home/Trash/info/a.txt.trashinfo'),
+            call.mkdirs('/cwd'),
+            call.move('/data_home/Trash/files/c.txt', '/cwd/c.txt'),
+            call.remove_file('/data_home/Trash/info/c.txt.trashinfo'),
+        ] == self.write_fs.mock_calls
+
+    def test_batch_restore_continues_after_move_error(self):
+        for name in ['a.txt', 'b.txt']:
+            self.fs.add_trash_file('/cwd/' + name, '/data_home/Trash',
+                                   datetime.datetime(2016, 1, 1), 'trashed')
+        self.write_fs.move.side_effect = [IOError('move failed'), None]
+
+        res = self.cmd_run(['trash-restore', '--sort=path'],
+                           reply='0,1', from_dir='/cwd')
+
+        assert 1 == res.exit_code
+        assert 'move failed\n' == res.stderr
+        assert [
+            call.mkdirs('/cwd'),
+            call.move('/data_home/Trash/files/a.txt', '/cwd/a.txt'),
+            call.mkdirs('/cwd'),
+            call.move('/data_home/Trash/files/b.txt', '/cwd/b.txt'),
+            call.remove_file('/data_home/Trash/info/b.txt.trashinfo'),
+        ] == self.write_fs.mock_calls
+
     def test_when_user_reply_with_not_number(self):
         self.fs.add_trash_file('/cwd/parent/foo.txt', '/data_home/Trash',
                                datetime.datetime(2016, 1, 1), 'boo')

--- a/tests/test_restore/cmd/test_restore_overwrite_guard.py
+++ b/tests/test_restore/cmd/test_restore_overwrite_guard.py
@@ -4,6 +4,7 @@ import unittest
 import pytest
 
 from tests.support.dirs.my_path import MyPath
+from tests.support.fakes.fake_trash_dir import trashinfo_content_default_date
 from tests.support.restore.restore_file_fixture import RestoreFileFixture
 from tests.support.restore.restore_user import RestoreUser
 from trashcli.fslib.real_fs_operations import RealListFilesInDir
@@ -51,3 +52,26 @@ class TestRestoreOverwriteGuard(unittest.TestCase):
 
     def tearDown(self):
         self.tmp_dir.clean_up()
+
+    def test_batch_keeps_conflicting_entry_and_restores_the_next_file(self):
+        trash = self.tmp_dir / 'XDG_DATA_HOME/Trash'
+        for name in ['a', 'b']:
+            self.fixture.make_file(trash / ('info/' + name + '.trashinfo'),
+                                   trashinfo_content_default_date(self.cwd / name))
+            self.fixture.make_file(trash / ('files/' + name), 'trashed ' + name)
+        self.fixture.make_file(self.cwd / 'a', 'existing a')
+
+        res = self.user.run_restore(args=['trash-restore', '--sort=path'],
+                                    reply='0-1', from_dir=self.cwd)
+
+        self.assertEqual(1, res.exit_code)
+        self.assertEqual('Refusing to overwrite existing file "a".\n', res.stderr)
+        with open(self.cwd / 'a') as restored:
+            self.assertEqual('existing a', restored.read())
+        with open(self.cwd / 'b') as restored:
+            self.assertEqual('trashed b', restored.read())
+        with open(trash / 'files/a') as remaining:
+            self.assertEqual('trashed a', remaining.read())
+        self.assertTrue(os.path.exists(trash / 'info/a.trashinfo'))
+        self.assertFalse(os.path.exists(trash / 'files/b'))
+        self.assertFalse(os.path.exists(trash / 'info/b.trashinfo'))

--- a/trashcli/restore/restore_asking_the_user.py
+++ b/trashcli/restore/restore_asking_the_user.py
@@ -1,6 +1,7 @@
 from typing import TypeVar, Generic, List, NamedTuple, Callable
 
 from six.moves import range
+from six import text_type
 
 from trashcli.lib.my_input import Input
 from trashcli.restore.index import Sequence
@@ -70,13 +71,16 @@ class RestoreAskingTheUser(object):
     def restore_selected_files(self,
                                selected_files,  # type: SelectedFiles
                                ):  # type: (...) -> Either[Die, None]
-        try:
-            for trashed_file in selected_files.files_to_restore:
+        errors = []
+        for trashed_file in selected_files.files_to_restore:
+            try:
                 self.restorer.restore_trashed_file(trashed_file,
                                                    selected_files.overwrite)
-            return Right(None)
-        except IOError as e:
-            return Left(Die(e))
+            except IOError as e:
+                errors.append(text_type(e))
+        if errors:
+            return Left(Die(u'\n'.join(errors)))
+        return Right(None)
 
 
 Error = TypeVar('Error')


### PR DESCRIPTION
## Summary

Fixes #376.

Catch restore errors per selected file, so a conflict or failed move does not prevent processing the remaining selection. Report all collected errors after the batch and retain the existing nonzero exit status when any item fails.

The overwrite checks and individual restore operations are unchanged. A failed move still leaves its trashinfo intact. Single-file errors keep their existing text, and successful batches gain no extra output.

The change stays compatible with Python 2 syntax and uses `six.text_type` consistently with `RealOutput` when formatting errors.

## Tests

- Both new command regressions fail before the fix: a range containing multiple conflicts, and an I/O error followed by a restorable file.
- A temporary-directory test verifies that a conflicting destination and its trashed copy/info survive while the next selected file is restored and its trashinfo removed.
- `.venv/bin/python -m pytest tests/test_restore -q`: 77 passed.
- `.venv/bin/python -m pytest -m 'not slow' -q`: 404 passed, 84 deselected (before adding the extra slow temporary-directory test).
- `git diff --check`: passed.
- `.venv/bin/mypy trashcli`: no issues in 158 source files.

Local tests used Python 3.12.12. Python 2.7 is not installed, so the Python-2-specific test/type/sdist checks and the full interpreter matrix were not run locally.

## AI assistance

Codex implemented this patch and ran the local checks at my request. This contribution is based on reproducing the issue, not a claim of personal production usage.
